### PR TITLE
Migrate xet transfers to xet-session API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1050,6 +1050,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=6232b42#6232b42591e8db8320f45d68bb8db94b2793ab46"
+dependencies = [
+ "async-trait",
+ "http",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ulid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1120,7 @@ dependencies = [
  "base64",
  "futures",
  "globset",
+ "hf-xet",
  "rand 0.9.2",
  "reqwest",
  "reqwest-middleware",
@@ -1115,7 +1134,6 @@ dependencies = [
  "typed-builder",
  "url",
  "xet-client",
- "xet-data",
 ]
 
 [[package]]
@@ -2375,7 +2393,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3512,7 +3530,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/huggingface_hub/Cargo.toml
+++ b/huggingface_hub/Cargo.toml
@@ -19,12 +19,12 @@ typed-builder = "0.20"
 globset = "0.4"
 base64 = "0.22"
 async-trait = { version = "0.1", optional = true }
-xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "6232b42", optional = true }
+hf-xet = { git = "https://github.com/huggingface/xet-core.git", rev = "6232b42", optional = true }
 xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "6232b42", optional = true }
 
 [features]
 default = []
-xet = ["dep:xet-data", "dep:xet-client", "dep:async-trait"]
+xet = ["dep:hf-xet", "dep:xet-client", "dep:async-trait"]
 spaces = []
 inference_endpoints = []
 collections = []

--- a/huggingface_hub/src/api/files.rs
+++ b/huggingface_hub/src/api/files.rs
@@ -113,19 +113,19 @@ impl HfApi {
     ///
     /// Endpoint: GET {endpoint}/{prefix}{repo_id}/resolve/{revision}/{filename}
     pub async fn download_file(&self, params: &DownloadFileParams) -> Result<PathBuf> {
+        let revision = params
+            .revision
+            .as_deref()
+            .unwrap_or(constants::DEFAULT_REVISION);
+        let url = self.download_url(
+            params.repo_type,
+            &params.repo_id,
+            revision,
+            &params.filename,
+        );
+
         #[cfg(feature = "xet")]
         {
-            let revision = params
-                .revision
-                .as_deref()
-                .unwrap_or(constants::DEFAULT_REVISION);
-            let url = self.download_url(
-                params.repo_type,
-                &params.repo_id,
-                revision,
-                &params.filename,
-            );
-
             let head_response = self
                 .inner
                 .client
@@ -144,58 +144,51 @@ impl HfApi {
                 )
                 .await?;
 
-            return crate::xet::xet_download(self, params, &head_response).await;
+            let has_xet_hash = head_response
+                .headers()
+                .get(constants::HEADER_X_XET_HASH)
+                .is_some();
+
+            if has_xet_hash {
+                return crate::xet::xet_download(self, params, &head_response).await;
+            }
         }
 
-        #[cfg(not(feature = "xet"))]
-        {
-            let revision = params
-                .revision
-                .as_deref()
-                .unwrap_or(constants::DEFAULT_REVISION);
-            let url = self.download_url(
-                params.repo_type,
-                &params.repo_id,
-                revision,
-                &params.filename,
-            );
+        let response = self
+            .inner
+            .client
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let response = self
+            .check_response(
+                response,
+                Some(&params.repo_id),
+                crate::error::NotFoundContext::Entry {
+                    path: params.filename.clone(),
+                },
+            )
+            .await?;
 
-            let response = self
-                .inner
-                .client
-                .get(&url)
-                .headers(self.auth_headers())
-                .send()
-                .await?;
-            let response = self
-                .check_response(
-                    response,
-                    Some(&params.repo_id),
-                    crate::error::NotFoundContext::Entry {
-                        path: params.filename.clone(),
-                    },
-                )
-                .await?;
+        tokio::fs::create_dir_all(&params.local_dir).await?;
 
-            tokio::fs::create_dir_all(&params.local_dir).await?;
-
-            let dest_path = params.local_dir.join(&params.filename);
-            if let Some(parent) = dest_path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
-
-            let mut file = tokio::fs::File::create(&dest_path).await?;
-            let mut stream = response.bytes_stream();
-            use tokio::io::AsyncWriteExt;
-
-            while let Some(chunk) = stream.next().await {
-                let chunk = chunk?;
-                file.write_all(&chunk).await?;
-            }
-            file.flush().await?;
-
-            Ok(dest_path)
+        let dest_path = params.local_dir.join(&params.filename);
+        if let Some(parent) = dest_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
         }
+
+        let mut file = tokio::fs::File::create(&dest_path).await?;
+        let mut stream = response.bytes_stream();
+        use tokio::io::AsyncWriteExt;
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            file.write_all(&chunk).await?;
+        }
+        file.flush().await?;
+
+        Ok(dest_path)
     }
 }
 

--- a/huggingface_hub/src/client.rs
+++ b/huggingface_hub/src/client.rs
@@ -22,6 +22,8 @@ pub(crate) struct HfApiInner {
     pub(crate) client: ClientWithMiddleware,
     pub(crate) endpoint: String,
     pub(crate) token: Option<String>,
+    #[cfg(feature = "xet")]
+    pub(crate) xet_session: std::sync::Mutex<Option<xet::xet_session::XetSession>>,
 }
 
 pub struct HfApiBuilder {
@@ -113,6 +115,8 @@ impl HfApiBuilder {
                 client,
                 endpoint: endpoint.trim_end_matches('/').to_string(),
                 token,
+                #[cfg(feature = "xet")]
+                xet_session: std::sync::Mutex::new(None),
             }),
         })
     }

--- a/huggingface_hub/src/xet.rs
+++ b/huggingface_hub/src/xet.rs
@@ -8,9 +8,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde::Deserialize;
+use xet::xet_session::{FileMetadata, XetFileInfo, XetSessionBuilder};
 use xet_client::cas_client::auth::{AuthError, TokenRefresher};
-use xet_data::processing::data_client;
-use xet_data::processing::{Sha256Policy, XetFileInfo};
 
 use crate::client::HfApi;
 use crate::constants;
@@ -97,9 +96,24 @@ async fn fetch_xet_connection_info(
     })
 }
 
+/// Build a XetSession with the given connection info and token refresher.
+async fn build_xet_session(
+    conn: &XetConnectionInfo,
+    token_refresher: Arc<dyn TokenRefresher>,
+) -> Result<xet::xet_session::XetSession> {
+    let (token, expiry) = conn.token_info();
+    XetSessionBuilder::new()
+        .with_endpoint(conn.endpoint.clone())
+        .with_token_info(token, expiry)
+        .with_token_refresher(token_refresher)
+        .build_async()
+        .await
+        .map_err(|e| HfError::Other(format!("Failed to build xet session: {e}")))
+}
+
 /// Download a file using the xet protocol.
 /// Extracts the file hash and size from the HEAD response headers,
-/// fetches a read token, and calls xet_data's download_async.
+/// fetches a read token, and uses xet-session's DownloadGroup.
 pub(crate) async fn xet_download(
     api: &HfApi,
     params: &DownloadFileParams,
@@ -141,26 +155,32 @@ pub(crate) async fn xet_download(
         tokio::fs::create_dir_all(parent).await?;
     }
 
-    let file_info = XetFileInfo::new(file_hash, file_size);
-    let dest_str = dest_path.to_string_lossy().to_string();
+    let session = build_xet_session(&conn, token_refresher).await?;
 
-    let token_info = conn.token_info();
-    data_client::download_async(
-        vec![(file_info, dest_str)],
-        Some(conn.endpoint),
-        Some(token_info),
-        Some(token_refresher),
-        None,
-        None,
-    )
-    .await
-    .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
+    let group = session
+        .new_download_group()
+        .await
+        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
+
+    let file_info = XetFileInfo {
+        hash: file_hash,
+        file_size,
+    };
+
+    group
+        .download_file_to_path(file_info, dest_path.clone())
+        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
+
+    group
+        .finish()
+        .await
+        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
 
     Ok(dest_path)
 }
 
 /// Upload files using the xet protocol.
-/// Fetches a write token and calls xet_data's upload functions.
+/// Fetches a write token and uses xet-session's UploadCommit.
 /// Returns the XetFileInfo (hash + size) for each uploaded file.
 #[allow(dead_code)]
 pub(crate) async fn xet_upload(
@@ -180,68 +200,50 @@ pub(crate) async fn xet_upload(
         token_type: "write",
     });
 
-    let mut path_files: Vec<String> = Vec::new();
-    let mut byte_files: Vec<Vec<u8>> = Vec::new();
-    let mut path_indices: Vec<usize> = Vec::new();
-    let mut byte_indices: Vec<usize> = Vec::new();
+    let session = build_xet_session(&conn, token_refresher).await?;
 
-    for (i, (_path_in_repo, source)) in files.iter().enumerate() {
-        match source {
-            AddSource::File(path) => {
-                path_files.push(path.to_string_lossy().to_string());
-                path_indices.push(i);
-            }
-            AddSource::Bytes(bytes) => {
-                byte_files.push(bytes.clone());
-                byte_indices.push(i);
-            }
-        }
-    }
-
-    let mut results: Vec<Option<XetFileInfo>> = vec![None; files.len()];
-
-    if !path_files.is_empty() {
-        let sha256_policies = vec![Sha256Policy::Compute; path_files.len()];
-        let infos = data_client::upload_async(
-            path_files,
-            sha256_policies,
-            Some(conn.endpoint.clone()),
-            Some(conn.token_info()),
-            Some(token_refresher.clone()),
-            None,
-            None,
-        )
+    let commit = session
+        .new_upload_commit()
         .await
-        .map_err(|e| HfError::Other(format!("Xet upload (files) failed: {e}")))?;
+        .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?;
 
-        for (idx, info) in path_indices.into_iter().zip(infos) {
-            results[idx] = Some(info);
-        }
+    let mut task_ids_in_order = Vec::with_capacity(files.len());
+
+    for (_path_in_repo, source) in files {
+        let handle = match source {
+            AddSource::File(path) => commit
+                .upload_from_path(path.clone())
+                .await
+                .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?,
+            AddSource::Bytes(bytes) => commit
+                .upload_bytes(bytes.clone(), None)
+                .await
+                .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?,
+        };
+        task_ids_in_order.push(handle.task_id);
     }
 
-    if !byte_files.is_empty() {
-        let sha256_policies = vec![Sha256Policy::Compute; byte_files.len()];
-        let infos = data_client::upload_bytes_async(
-            byte_files,
-            sha256_policies,
-            Some(conn.endpoint.clone()),
-            Some(conn.token_info()),
-            Some(token_refresher),
-            None,
-            None,
-        )
+    let results = commit
+        .commit()
         .await
-        .map_err(|e| HfError::Other(format!("Xet upload (bytes) failed: {e}")))?;
+        .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?;
 
-        for (idx, info) in byte_indices.into_iter().zip(infos) {
-            results[idx] = Some(info);
-        }
+    let mut xet_file_infos = Vec::with_capacity(files.len());
+    for task_id in &task_ids_in_order {
+        let result = results
+            .get(task_id)
+            .ok_or_else(|| HfError::Other("Missing xet upload result for task".to_string()))?;
+        let metadata: &FileMetadata = result
+            .as_ref()
+            .as_ref()
+            .map_err(|e| HfError::Other(format!("Xet upload task failed: {e}")))?;
+        xet_file_infos.push(XetFileInfo {
+            hash: metadata.hash.clone(),
+            file_size: metadata.file_size,
+        });
     }
 
-    results
-        .into_iter()
-        .collect::<Option<Vec<_>>>()
-        .ok_or_else(|| HfError::Other("Unexpected missing xet upload result".to_string()))
+    Ok(xet_file_infos)
 }
 
 impl HfApi {

--- a/huggingface_hub/src/xet.rs
+++ b/huggingface_hub/src/xet.rs
@@ -96,21 +96,6 @@ async fn fetch_xet_connection_info(
     })
 }
 
-/// Build a XetSession with the given connection info and token refresher.
-async fn build_xet_session(
-    conn: &XetConnectionInfo,
-    token_refresher: Arc<dyn TokenRefresher>,
-) -> Result<xet::xet_session::XetSession> {
-    let (token, expiry) = conn.token_info();
-    XetSessionBuilder::new()
-        .with_endpoint(conn.endpoint.clone())
-        .with_token_info(token, expiry)
-        .with_token_refresher(token_refresher)
-        .build_async()
-        .await
-        .map_err(|e| HfError::Other(format!("Failed to build xet session: {e}")))
-}
-
 /// Download a file using the xet protocol.
 /// Extracts the file hash and size from the HEAD response headers,
 /// fetches a read token, and uses xet-session's DownloadGroup.
@@ -138,24 +123,15 @@ pub(crate) async fn xet_download(
         .as_deref()
         .unwrap_or(constants::DEFAULT_REVISION);
 
-    let conn =
-        fetch_xet_connection_info(api, "read", &params.repo_id, params.repo_type, revision).await?;
-
-    let token_refresher: Arc<dyn TokenRefresher> = Arc::new(HubTokenRefresher {
-        api: api.clone(),
-        repo_id: params.repo_id.clone(),
-        repo_type: params.repo_type,
-        revision: revision.to_string(),
-        token_type: "read",
-    });
+    let session = api
+        .get_or_init_xet_session("read", &params.repo_id, params.repo_type, revision)
+        .await?;
 
     tokio::fs::create_dir_all(&params.local_dir).await?;
     let dest_path = params.local_dir.join(&params.filename);
     if let Some(parent) = dest_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-
-    let session = build_xet_session(&conn, token_refresher).await?;
 
     let group = session
         .new_download_group()
@@ -190,17 +166,9 @@ pub(crate) async fn xet_upload(
     repo_type: Option<RepoType>,
     revision: &str,
 ) -> Result<Vec<XetFileInfo>> {
-    let conn = fetch_xet_connection_info(api, "write", repo_id, repo_type, revision).await?;
-
-    let token_refresher: Arc<dyn TokenRefresher> = Arc::new(HubTokenRefresher {
-        api: api.clone(),
-        repo_id: repo_id.to_string(),
-        repo_type,
-        revision: revision.to_string(),
-        token_type: "write",
-    });
-
-    let session = build_xet_session(&conn, token_refresher).await?;
+    let session = api
+        .get_or_init_xet_session("write", repo_id, repo_type, revision)
+        .await?;
 
     let commit = session
         .new_upload_commit()
@@ -247,6 +215,62 @@ pub(crate) async fn xet_upload(
 }
 
 impl HfApi {
+    /// Return the cached XetSession, creating it on first use.
+    ///
+    /// The session is built once per HfApi lifetime and reused for all
+    /// subsequent xet operations. A token refresher is installed so the
+    /// session can renew its CAS credentials when they expire.
+    async fn get_or_init_xet_session(
+        &self,
+        token_type: &'static str,
+        repo_id: &str,
+        repo_type: Option<RepoType>,
+        revision: &str,
+    ) -> Result<xet::xet_session::XetSession> {
+        {
+            let guard = self
+                .inner
+                .xet_session
+                .lock()
+                .map_err(|e| HfError::Other(format!("xet session lock poisoned: {e}")))?;
+            if let Some(session) = guard.as_ref() {
+                return Ok(session.clone());
+            }
+        }
+
+        let conn =
+            fetch_xet_connection_info(self, token_type, repo_id, repo_type, revision).await?;
+
+        let token_refresher: Arc<dyn TokenRefresher> = Arc::new(HubTokenRefresher {
+            api: self.clone(),
+            repo_id: repo_id.to_string(),
+            repo_type,
+            revision: revision.to_string(),
+            token_type,
+        });
+
+        let (token, expiry) = conn.token_info();
+        let session = XetSessionBuilder::new()
+            .with_endpoint(conn.endpoint.clone())
+            .with_token_info(token, expiry)
+            .with_token_refresher(token_refresher)
+            .build_async()
+            .await
+            .map_err(|e| HfError::Other(format!("Failed to build xet session: {e}")))?;
+
+        let mut guard = self
+            .inner
+            .xet_session
+            .lock()
+            .map_err(|e| HfError::Other(format!("xet session lock poisoned: {e}")))?;
+        if let Some(existing) = guard.as_ref() {
+            Ok(existing.clone())
+        } else {
+            *guard = Some(session.clone());
+            Ok(session)
+        }
+    }
+
     /// Fetch a Xet connection token (read or write) for a repository.
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/xet-{read|write}-token/{revision}
     pub async fn get_xet_token(&self, params: &GetXetTokenParams) -> Result<XetConnectionInfo> {


### PR DESCRIPTION
## Summary

- Replace low-level `xet-data` (`data_client::download_async`/`upload_async`) with the higher-level `xet-session` API from the `hf-xet` crate (`XetSession` → `DownloadGroup`/`UploadCommit`)
- Remove `xet-data` dependency; add `hf-xet` dependency (same git rev `6232b42`)
- Keep `xet-client` only for the `TokenRefresher` trait (not re-exported by `hf-xet` yet)
- Fix `download_file()` to fall back to regular HTTP when `X-Xet-Hash` header is absent, so small files uploaded via inline NDJSON still download correctly

## Test plan

- [x] `cargo check -p huggingface-hub` (without xet feature)
- [x] `cargo check -p huggingface-hub --features xet`
- [x] `cargo clippy -p huggingface-hub --features xet -- -D warnings`
- [x] All unit tests pass (10/10)
- [x] All download tests pass (9/9)
- [x] All integration tests pass including writes (33/33)
- [x] All xet transfer tests pass including writes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)