### PR TITLE
Add examples directory covering full API surface

### DIFF
--- a/huggingface_hub/Cargo.toml
+++ b/huggingface_hub/Cargo.toml
@@ -41,3 +41,64 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
 rand = "0.9"
 sha2 = "0.10"
+
+[[example]]
+name = "repo"
+path = "examples/repo.rs"
+
+[[example]]
+name = "files"
+path = "examples/files.rs"
+
+[[example]]
+name = "commits"
+path = "examples/commits.rs"
+
+[[example]]
+name = "users"
+path = "examples/users.rs"
+
+[[example]]
+name = "spaces"
+path = "examples/spaces.rs"
+required-features = ["spaces"]
+
+[[example]]
+name = "inference_endpoints"
+path = "examples/inference_endpoints.rs"
+required-features = ["inference_endpoints"]
+
+[[example]]
+name = "collections"
+path = "examples/collections.rs"
+required-features = ["collections"]
+
+[[example]]
+name = "discussions"
+path = "examples/discussions.rs"
+required-features = ["discussions"]
+
+[[example]]
+name = "webhooks"
+path = "examples/webhooks.rs"
+required-features = ["webhooks"]
+
+[[example]]
+name = "jobs"
+path = "examples/jobs.rs"
+required-features = ["jobs"]
+
+[[example]]
+name = "access_requests"
+path = "examples/access_requests.rs"
+required-features = ["access_requests"]
+
+[[example]]
+name = "likes"
+path = "examples/likes.rs"
+required-features = ["likes"]
+
+[[example]]
+name = "papers"
+path = "examples/papers.rs"
+required-features = ["papers"]

--- a/huggingface_hub/examples/access_requests.rs
+++ b/huggingface_hub/examples/access_requests.rs
@@ -1,0 +1,59 @@
+//! Access request operations: list pending/accepted/rejected requests.
+//!
+//! Requires HF_TOKEN and the "access_requests" feature.
+//! Run: cargo run -p huggingface-hub --features access_requests --example access_requests
+
+use huggingface_hub::{
+    CreateRepoParams, DeleteRepoParams, HfApi, ListAccessRequestsParams, UpdateRepoParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let repo_name = format!("{}/example-gated-{unique}", user.username);
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&repo_name)
+            .private(true)
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+
+    api.update_repo_settings(
+        &UpdateRepoParams::builder()
+            .repo_id(&repo_name)
+            .gated("auto")
+            .build(),
+    )
+    .await?;
+    println!("Created gated repo: {repo_name}");
+
+    let params = ListAccessRequestsParams::builder()
+        .repo_id(&repo_name)
+        .build();
+
+    let pending = api.list_pending_access_requests(&params).await?;
+    println!("Pending requests: {}", pending.len());
+
+    let accepted = api.list_accepted_access_requests(&params).await?;
+    println!("Accepted requests: {}", accepted.len());
+
+    let rejected = api.list_rejected_access_requests(&params).await?;
+    println!("Rejected requests: {}", rejected.len());
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&repo_name)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Cleaned up test repo");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/collections.rs
+++ b/huggingface_hub/examples/collections.rs
@@ -1,0 +1,111 @@
+//! Collection operations: list, create, manage items, and delete.
+//!
+//! Requires HF_TOKEN and the "collections" feature.
+//! Run: cargo run -p huggingface-hub --features collections --example collections
+
+use huggingface_hub::{
+    AddCollectionItemParams, CreateCollectionParams, DeleteCollectionItemParams,
+    DeleteCollectionParams, GetCollectionParams, HfApi, ListCollectionsParams,
+    UpdateCollectionItemParams, UpdateCollectionMetadataParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let collections = api
+        .list_collections(
+            &ListCollectionsParams::builder()
+                .owner("huggingface")
+                .limit(3_usize)
+                .build(),
+        )
+        .await?;
+    println!("Collections by huggingface:");
+    for c in &collections {
+        println!("  - {} ({:?})", c.slug, c.title);
+    }
+
+    if let Some(first) = collections.first() {
+        let detail = api
+            .get_collection(&GetCollectionParams::builder().slug(&first.slug).build())
+            .await?;
+        println!(
+            "\nCollection detail: {} ({} items)",
+            detail.slug,
+            detail.items.len()
+        );
+    }
+
+    // --- Write operations ---
+
+    let collection = api
+        .create_collection(
+            &CreateCollectionParams::builder()
+                .title("Example Collection")
+                .description("Created by huggingface-hub Rust example")
+                .private(true)
+                .build(),
+        )
+        .await?;
+    println!("\nCreated collection: {}", collection.slug);
+
+    let updated = api
+        .update_collection_metadata(
+            &UpdateCollectionMetadataParams::builder()
+                .slug(&collection.slug)
+                .description("Updated description")
+                .build(),
+        )
+        .await?;
+    println!("Updated collection: {:?}", updated.description);
+
+    let with_item = api
+        .add_collection_item(
+            &AddCollectionItemParams::builder()
+                .slug(&collection.slug)
+                .item_id("gpt2")
+                .item_type("model")
+                .note("Classic GPT-2 model")
+                .build(),
+        )
+        .await?;
+    let item_id = with_item
+        .items
+        .last()
+        .and_then(|i| i.item_object_id.clone())
+        .expect("item should have an id");
+    println!("Added item to collection (id: {item_id})");
+
+    let updated_item = api
+        .update_collection_item(
+            &UpdateCollectionItemParams::builder()
+                .slug(&collection.slug)
+                .item_object_id(&item_id)
+                .note("Updated note for GPT-2")
+                .build(),
+        )
+        .await?;
+    println!("Updated item note: {:?}", updated_item.note);
+
+    api.delete_collection_item(
+        &DeleteCollectionItemParams::builder()
+            .slug(&collection.slug)
+            .item_object_id(&item_id)
+            .build(),
+    )
+    .await?;
+    println!("Deleted item from collection");
+
+    api.delete_collection(
+        &DeleteCollectionParams::builder()
+            .slug(&collection.slug)
+            .build(),
+    )
+    .await?;
+    println!("Deleted collection");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/commits.rs
+++ b/huggingface_hub/examples/commits.rs
@@ -1,0 +1,135 @@
+//! Commit operations: listing commits, refs, diffs, and branch/tag management.
+//!
+//! Requires HF_TOKEN environment variable.
+//! Run: cargo run -p huggingface-hub --example commits
+
+use futures::StreamExt;
+use huggingface_hub::{
+    CreateBranchParams, CreateRepoParams, CreateTagParams, DeleteBranchParams, DeleteRepoParams,
+    DeleteTagParams, GetCommitDiffParams, GetRawDiffParams, HfApi, ListRepoCommitsParams,
+    ListRepoRefsParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let commits_stream =
+        api.list_repo_commits(&ListRepoCommitsParams::builder().repo_id("gpt2").build());
+    futures::pin_mut!(commits_stream);
+    println!("Recent commits in gpt2:");
+    let mut first_two_ids: Vec<String> = Vec::new();
+    let mut count = 0;
+    while let Some(Ok(commit)) = commits_stream.next().await {
+        println!("  {} - {}", &commit.id[..8], commit.title);
+        if first_two_ids.len() < 2 {
+            first_two_ids.push(commit.id.clone());
+        }
+        count += 1;
+        if count >= 5 {
+            break;
+        }
+    }
+
+    let refs = api
+        .list_repo_refs(&ListRepoRefsParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("\nBranches:");
+    for b in &refs.branches {
+        println!("  {} -> {}", b.name, &b.target_commit[..8]);
+    }
+    println!("Tags:");
+    for t in &refs.tags {
+        println!("  {} -> {}", t.name, &t.target_commit[..8]);
+    }
+
+    if first_two_ids.len() == 2 {
+        let compare = format!("{}..{}", first_two_ids[1], first_two_ids[0]);
+        let diff = api
+            .get_commit_diff(
+                &GetCommitDiffParams::builder()
+                    .repo_id("gpt2")
+                    .compare(&compare)
+                    .build(),
+            )
+            .await?;
+        println!("\nDiff ({compare}):");
+        println!("  {} chars", diff.len());
+
+        let raw_diff = api
+            .get_raw_diff(
+                &GetRawDiffParams::builder()
+                    .repo_id("gpt2")
+                    .compare(&compare)
+                    .build(),
+            )
+            .await?;
+        println!("Raw diff: {} chars", raw_diff.len());
+    }
+
+    // --- Write operations (creates real resources on the Hub) ---
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let repo_name = format!("{}/example-commits-{unique}", user.username);
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&repo_name)
+            .private(true)
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("\nCreated test repo: {repo_name}");
+
+    api.create_branch(
+        &CreateBranchParams::builder()
+            .repo_id(&repo_name)
+            .branch("feature-branch")
+            .build(),
+    )
+    .await?;
+    println!("Created branch: feature-branch");
+
+    api.delete_branch(
+        &DeleteBranchParams::builder()
+            .repo_id(&repo_name)
+            .branch("feature-branch")
+            .build(),
+    )
+    .await?;
+    println!("Deleted branch: feature-branch");
+
+    api.create_tag(
+        &CreateTagParams::builder()
+            .repo_id(&repo_name)
+            .tag("v0.1.0")
+            .message("Initial release")
+            .build(),
+    )
+    .await?;
+    println!("Created tag: v0.1.0");
+
+    api.delete_tag(
+        &DeleteTagParams::builder()
+            .repo_id(&repo_name)
+            .tag("v0.1.0")
+            .build(),
+    )
+    .await?;
+    println!("Deleted tag: v0.1.0");
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&repo_name)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Cleaned up test repo");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/discussions.rs
+++ b/huggingface_hub/examples/discussions.rs
@@ -1,0 +1,124 @@
+//! Discussion operations: list, create, comment, and pull request management.
+//!
+//! Requires HF_TOKEN and the "discussions" feature.
+//! Run: cargo run -p huggingface-hub --features discussions --example discussions
+
+use huggingface_hub::{
+    ChangeDiscussionStatusParams, CommentDiscussionParams, CreateDiscussionParams,
+    CreateRepoParams, DeleteRepoParams, EditDiscussionCommentParams, GetDiscussionDetailsParams,
+    GetRepoDiscussionsParams, HfApi, RenameDiscussionParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let discussions = api
+        .get_repo_discussions(&GetRepoDiscussionsParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!(
+        "Discussions in gpt2: {} (total: {:?})",
+        discussions.discussions.len(),
+        discussions.count
+    );
+
+    if let Some(first) = discussions.discussions.first() {
+        let details = api
+            .get_discussion_details(
+                &GetDiscussionDetailsParams::builder()
+                    .repo_id("gpt2")
+                    .discussion_num(first.num)
+                    .build(),
+            )
+            .await?;
+        println!(
+            "Discussion #{}: {:?} (status: {:?})",
+            details.num, details.title, details.status
+        );
+    }
+
+    // --- Write operations ---
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let repo_name = format!("{}/example-discussions-{unique}", user.username);
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&repo_name)
+            .private(true)
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("\nCreated test repo: {repo_name}");
+
+    let discussion = api
+        .create_discussion(
+            &CreateDiscussionParams::builder()
+                .repo_id(&repo_name)
+                .title("Example Discussion")
+                .description("Created by Rust example")
+                .build(),
+        )
+        .await?;
+    println!("Created discussion #{}", discussion.num);
+
+    let comment = api
+        .comment_discussion(
+            &CommentDiscussionParams::builder()
+                .repo_id(&repo_name)
+                .discussion_num(discussion.num)
+                .comment("This is a test comment")
+                .build(),
+        )
+        .await?;
+    let comment_id = comment.id.expect("comment should have an id");
+    println!("Added comment: {comment_id}");
+
+    let edited = api
+        .edit_discussion_comment(
+            &EditDiscussionCommentParams::builder()
+                .repo_id(&repo_name)
+                .discussion_num(discussion.num)
+                .comment_id(&comment_id)
+                .new_content("Edited test comment")
+                .build(),
+        )
+        .await?;
+    println!("Edited comment: {:?}", edited.id);
+
+    let renamed = api
+        .rename_discussion(
+            &RenameDiscussionParams::builder()
+                .repo_id(&repo_name)
+                .discussion_num(discussion.num)
+                .new_title("Renamed Example Discussion")
+                .build(),
+        )
+        .await?;
+    println!("Renamed discussion: {:?}", renamed.title);
+
+    api.change_discussion_status(
+        &ChangeDiscussionStatusParams::builder()
+            .repo_id(&repo_name)
+            .discussion_num(discussion.num)
+            .new_status("closed")
+            .build(),
+    )
+    .await?;
+    println!("Closed discussion");
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&repo_name)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Cleaned up test repo");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/files.rs
+++ b/huggingface_hub/examples/files.rs
@@ -1,0 +1,164 @@
+//! File operations: listing, downloading, uploading, and committing.
+//!
+//! Requires HF_TOKEN environment variable.
+//! Run: cargo run -p huggingface-hub --example files
+
+use futures::StreamExt;
+use huggingface_hub::{
+    AddSource, CommitOperation, CreateCommitParams, CreateRepoParams, DeleteFileParams,
+    DeleteFolderParams, DeleteRepoParams, DownloadFileParams, GetPathsInfoParams, HfApi,
+    ListRepoFilesParams, ListRepoTreeParams, RepoTreeEntry, UploadFileParams, UploadFolderParams,
+};
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let files = api
+        .list_repo_files(&ListRepoFilesParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("Files in gpt2: {}", files.len());
+    for f in files.iter().take(5) {
+        println!("  - {f}");
+    }
+
+    let tree_stream = api.list_repo_tree(
+        &ListRepoTreeParams::builder()
+            .repo_id("gpt2")
+            .recursive(true)
+            .build(),
+    );
+    futures::pin_mut!(tree_stream);
+    println!("\nTree entries in gpt2:");
+    let mut count = 0;
+    while let Some(Ok(entry)) = tree_stream.next().await {
+        match &entry {
+            RepoTreeEntry::File { path, size, .. } => println!("  file: {path} ({size} bytes)"),
+            RepoTreeEntry::Directory { path, .. } => println!("  dir:  {path}"),
+        }
+        count += 1;
+        if count >= 5 {
+            break;
+        }
+    }
+
+    let paths_info = api
+        .get_paths_info(
+            &GetPathsInfoParams::builder()
+                .repo_id("gpt2")
+                .paths(vec!["config.json".to_string(), "README.md".to_string()])
+                .build(),
+        )
+        .await?;
+    println!("\nPaths info for gpt2:");
+    for entry in &paths_info {
+        println!("  {entry:?}");
+    }
+
+    let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
+    let downloaded = api
+        .download_file(
+            &DownloadFileParams::builder()
+                .repo_id("gpt2")
+                .filename("config.json")
+                .local_dir(tmp_dir.path().to_path_buf())
+                .build(),
+        )
+        .await?;
+    println!("\nDownloaded gpt2/config.json to: {}", downloaded.display());
+
+    // --- Write operations (creates real resources on the Hub) ---
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let repo_name = format!("{}/example-files-{unique}", user.username);
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&repo_name)
+            .private(true)
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("\nCreated test repo: {repo_name}");
+
+    let commit = api
+        .upload_file(
+            &UploadFileParams::builder()
+                .repo_id(&repo_name)
+                .source(AddSource::Bytes(b"Hello from Rust!".to_vec()))
+                .path_in_repo("hello.txt")
+                .commit_message("Add hello.txt via example")
+                .build(),
+        )
+        .await?;
+    println!("Uploaded hello.txt: {:?}", commit.commit_url);
+
+    let commit = api
+        .create_commit(
+            &CreateCommitParams::builder()
+                .repo_id(&repo_name)
+                .operations(vec![
+                    CommitOperation::Add {
+                        path_in_repo: "data/file1.txt".to_string(),
+                        source: AddSource::Bytes(b"File 1 content".to_vec()),
+                    },
+                    CommitOperation::Add {
+                        path_in_repo: "data/file2.txt".to_string(),
+                        source: AddSource::Bytes(b"File 2 content".to_vec()),
+                    },
+                ])
+                .commit_message("Add data files via create_commit")
+                .build(),
+        )
+        .await?;
+    println!("Created commit with 2 files: {:?}", commit.commit_oid);
+
+    let upload_dir = tmp_dir.path().join("upload_folder");
+    std::fs::create_dir_all(upload_dir.join("subdir")).expect("failed to create dir");
+    std::fs::write(upload_dir.join("root.txt"), "root file").expect("failed to write");
+    std::fs::write(upload_dir.join("subdir/nested.txt"), "nested file").expect("failed to write");
+
+    let commit = api
+        .upload_folder(
+            &UploadFolderParams::builder()
+                .repo_id(&repo_name)
+                .folder_path(upload_dir)
+                .path_in_repo("uploaded")
+                .commit_message("Upload folder via example")
+                .build(),
+        )
+        .await?;
+    println!("Uploaded folder: {:?}", commit.commit_oid);
+
+    api.delete_file(
+        &DeleteFileParams::builder()
+            .repo_id(&repo_name)
+            .path_in_repo("hello.txt")
+            .build(),
+    )
+    .await?;
+    println!("Deleted hello.txt");
+
+    api.delete_folder(
+        &DeleteFolderParams::builder()
+            .repo_id(&repo_name)
+            .path_in_repo("data")
+            .build(),
+    )
+    .await?;
+    println!("Deleted data/ folder");
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&repo_name)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Cleaned up test repo");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/inference_endpoints.rs
+++ b/huggingface_hub/examples/inference_endpoints.rs
@@ -1,0 +1,106 @@
+//! Inference Endpoint operations: list, create, update, pause, resume, and delete.
+//!
+//! WARNING: Creating inference endpoints costs money. The create/delete operations
+//! are guarded behind the HF_TEST_IE=1 environment variable.
+//!
+//! Requires HF_TOKEN and the "inference_endpoints" feature.
+//! Run: cargo run -p huggingface-hub --features inference_endpoints --example inference_endpoints
+
+use huggingface_hub::{
+    CreateInferenceEndpointParams, DeleteInferenceEndpointParams, GetInferenceEndpointParams,
+    HfApi, ListInferenceEndpointsParams, PauseInferenceEndpointParams,
+    ResumeInferenceEndpointParams, ScaleToZeroInferenceEndpointParams,
+    UpdateInferenceEndpointParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    let endpoints = api
+        .list_inference_endpoints(&ListInferenceEndpointsParams::builder().build())
+        .await?;
+    println!("Inference endpoints: {}", endpoints.len());
+    for ep in &endpoints {
+        println!("  - {:?}", ep);
+    }
+
+    if std::env::var("HF_TEST_IE").is_err() {
+        println!("\nSet HF_TEST_IE=1 to run create/update/delete operations (costs money)");
+        return Ok(());
+    }
+
+    let unique = std::process::id();
+    let ep_name = format!("example-ep-{unique}");
+
+    let created = api
+        .create_inference_endpoint(
+            &CreateInferenceEndpointParams::builder()
+                .name(&ep_name)
+                .repository("gpt2")
+                .framework("pytorch")
+                .task("text-generation")
+                .accelerator("cpu")
+                .instance_size("x1")
+                .instance_type("c6i")
+                .region("us-east-1")
+                .vendor("aws")
+                .min_replica(0_u32)
+                .max_replica(1_u32)
+                .build(),
+        )
+        .await?;
+    println!("\nCreated endpoint: {:?}", created);
+
+    let fetched = api
+        .get_inference_endpoint(&GetInferenceEndpointParams::builder().name(&ep_name).build())
+        .await?;
+    println!("Fetched endpoint: {:?}", fetched);
+
+    let updated = api
+        .update_inference_endpoint(
+            &UpdateInferenceEndpointParams::builder()
+                .name(&ep_name)
+                .min_replica(0_u32)
+                .build(),
+        )
+        .await?;
+    println!("Updated endpoint: {:?}", updated);
+
+    let paused = api
+        .pause_inference_endpoint(
+            &PauseInferenceEndpointParams::builder()
+                .name(&ep_name)
+                .build(),
+        )
+        .await?;
+    println!("Paused endpoint: {:?}", paused);
+
+    let resumed = api
+        .resume_inference_endpoint(
+            &ResumeInferenceEndpointParams::builder()
+                .name(&ep_name)
+                .build(),
+        )
+        .await?;
+    println!("Resumed endpoint: {:?}", resumed);
+
+    let scaled = api
+        .scale_to_zero_inference_endpoint(
+            &ScaleToZeroInferenceEndpointParams::builder()
+                .name(&ep_name)
+                .build(),
+        )
+        .await?;
+    println!("Scaled to zero: {:?}", scaled);
+
+    api.delete_inference_endpoint(
+        &DeleteInferenceEndpointParams::builder()
+            .name(&ep_name)
+            .build(),
+    )
+    .await?;
+    println!("Deleted endpoint");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/jobs.rs
+++ b/huggingface_hub/examples/jobs.rs
@@ -1,0 +1,65 @@
+//! Job operations: list hardware, run jobs, inspect, cancel, and scheduled jobs.
+//!
+//! Requires HF_TOKEN and the "jobs" feature.
+//! Run: cargo run -p huggingface-hub --features jobs --example jobs
+
+use huggingface_hub::{CreateScheduledJobParams, HfApi, ListJobsParams, RunJobParams};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    let hardware = api.list_job_hardware().await?;
+    println!("Available job hardware:");
+    for hw in &hardware {
+        println!("  - {:?}", hw);
+    }
+
+    let jobs = api.list_jobs(&ListJobsParams::builder().build()).await?;
+    println!("\nExisting jobs: {}", jobs.len());
+    for job in jobs.iter().take(3) {
+        println!("  - {:?}", job);
+    }
+
+    let job = api
+        .run_job(
+            &RunJobParams::builder()
+                .image("ubuntu:latest")
+                .command(vec!["echo".to_string(), "Hello from Rust!".to_string()])
+                .flavor("cpu-basic")
+                .build(),
+        )
+        .await?;
+    let job_id = &job.id;
+    println!("\nStarted job: {job_id}");
+
+    let inspected = api.inspect_job(job_id, None).await?;
+    println!("Job status: {:?}", inspected.status);
+
+    let cancelled = api.cancel_job(job_id, None).await?;
+    println!("Cancelled job: {:?}", cancelled.status);
+
+    let scheduled = api
+        .create_scheduled_job(
+            &CreateScheduledJobParams::builder()
+                .image("ubuntu:latest")
+                .command(vec!["echo".to_string(), "scheduled".to_string()])
+                .schedule("0 0 * * *")
+                .flavor("cpu-basic")
+                .build(),
+        )
+        .await?;
+    let sched_id = &scheduled.id;
+    println!("\nCreated scheduled job: {sched_id}");
+
+    let all_scheduled = api.list_scheduled_jobs().await?;
+    println!("Scheduled jobs: {}", all_scheduled.len());
+
+    let inspected_sched = api.inspect_scheduled_job(sched_id).await?;
+    println!("Scheduled job: {:?}", inspected_sched);
+
+    api.delete_scheduled_job(sched_id).await?;
+    println!("Deleted scheduled job");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/likes.rs
+++ b/huggingface_hub/examples/likes.rs
@@ -1,0 +1,48 @@
+//! Like operations: like/unlike repos, list liked repos and likers.
+//!
+//! Requires HF_TOKEN and the "likes" feature.
+//! Run: cargo run -p huggingface-hub --features likes --example likes
+
+use futures::StreamExt;
+use huggingface_hub::{HfApi, LikeParams, ListLikedReposParams, ListRepoLikersParams};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    let user = api.whoami().await?;
+    let liked = api
+        .list_liked_repos(
+            &ListLikedReposParams::builder()
+                .username(&user.username)
+                .build(),
+        )
+        .await?;
+    println!("Liked repos by {}:", user.username);
+    for repo in liked.iter().take(5) {
+        println!("  - {:?}", repo);
+    }
+
+    let likers_stream =
+        api.list_repo_likers(&ListRepoLikersParams::builder().repo_id("gpt2").build());
+    futures::pin_mut!(likers_stream);
+    println!("\nLikers of gpt2:");
+    let mut count = 0;
+    while let Some(Ok(liker)) = likers_stream.next().await {
+        println!("  - {}", liker.username);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    api.like(&LikeParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("\nLiked gpt2");
+
+    api.unlike(&LikeParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("Unliked gpt2");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/papers.rs
+++ b/huggingface_hub/examples/papers.rs
@@ -1,0 +1,41 @@
+//! Paper operations: search, daily papers, and paper info.
+//!
+//! Requires HF_TOKEN and the "papers" feature.
+//! Run: cargo run -p huggingface-hub --features papers --example papers
+
+use huggingface_hub::{HfApi, ListDailyPapersParams, ListPapersParams, PaperInfoParams};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    let results = api
+        .list_papers(
+            &ListPapersParams::builder()
+                .query("transformers")
+                .limit(3_usize)
+                .build(),
+        )
+        .await?;
+    println!("Paper search results for 'transformers':");
+    for paper in &results {
+        println!("  - {:?}", paper);
+    }
+
+    let daily = api
+        .list_daily_papers(&ListDailyPapersParams::builder().limit(3_usize).build())
+        .await?;
+    println!("\nRecent daily papers:");
+    for paper in &daily {
+        println!("  - {:?}", paper);
+    }
+
+    if let Some(first) = results.first().and_then(|r| r.paper.as_ref()) {
+        let info = api
+            .paper_info(&PaperInfoParams::builder().paper_id(&first.id).build())
+            .await?;
+        println!("\nPaper info: {:?}", info);
+    }
+
+    Ok(())
+}

--- a/huggingface_hub/examples/repo.rs
+++ b/huggingface_hub/examples/repo.rs
@@ -1,0 +1,153 @@
+//! Repository operations: info, listing, existence checks, and CRUD.
+//!
+//! Requires HF_TOKEN environment variable.
+//! Run: cargo run -p huggingface-hub --example repo
+
+use futures::StreamExt;
+use huggingface_hub::{
+    CreateRepoParams, DatasetInfoParams, DeleteRepoParams, FileExistsParams, HfApi,
+    ListDatasetsParams, ListModelsParams, ListSpacesParams, ModelInfoParams, MoveRepoParams,
+    RepoExistsParams, RevisionExistsParams, SpaceInfoParams, UpdateRepoParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let model = api
+        .model_info(&ModelInfoParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("Model: {} (downloads: {:?})", model.id, model.downloads);
+
+    let dataset = api
+        .dataset_info(
+            &DatasetInfoParams::builder()
+                .repo_id("rajpurkar/squad")
+                .build(),
+        )
+        .await?;
+    println!(
+        "Dataset: {} (downloads: {:?})",
+        dataset.id, dataset.downloads
+    );
+
+    let space = api
+        .space_info(
+            &SpaceInfoParams::builder()
+                .repo_id("huggingface/transformers-benchmarks")
+                .build(),
+        )
+        .await?;
+    println!("Space: {} (sdk: {:?})", space.id, space.sdk);
+
+    let exists = api
+        .repo_exists(&RepoExistsParams::builder().repo_id("gpt2").build())
+        .await?;
+    println!("gpt2 exists: {exists}");
+
+    let rev_exists = api
+        .revision_exists(
+            &RevisionExistsParams::builder()
+                .repo_id("gpt2")
+                .revision("main")
+                .build(),
+        )
+        .await?;
+    println!("gpt2@main exists: {rev_exists}");
+
+    let file_exists = api
+        .file_exists(
+            &FileExistsParams::builder()
+                .repo_id("gpt2")
+                .filename("config.json")
+                .build(),
+        )
+        .await?;
+    println!("gpt2/config.json exists: {file_exists}");
+
+    let models_stream = api.list_models(&ListModelsParams::builder().author("openai").build());
+    futures::pin_mut!(models_stream);
+    println!("\nModels by openai:");
+    let mut count = 0;
+    while let Some(Ok(model)) = models_stream.next().await {
+        println!("  - {}", model.id);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    let datasets_stream = api.list_datasets(&ListDatasetsParams::builder().search("squad").build());
+    futures::pin_mut!(datasets_stream);
+    println!("\nDatasets matching 'squad':");
+    let mut count = 0;
+    while let Some(Ok(ds)) = datasets_stream.next().await {
+        println!("  - {}", ds.id);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    let spaces_stream = api.list_spaces(&ListSpacesParams::builder().author("huggingface").build());
+    futures::pin_mut!(spaces_stream);
+    println!("\nSpaces by huggingface:");
+    let mut count = 0;
+    while let Some(Ok(sp)) = spaces_stream.next().await {
+        println!("  - {}", sp.id);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    // --- Write operations (creates real resources on the Hub) ---
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let repo_name = format!("{}/example-repo-{unique}", user.username);
+
+    let repo_url = api
+        .create_repo(
+            &CreateRepoParams::builder()
+                .repo_id(&repo_name)
+                .private(true)
+                .exist_ok(true)
+                .build(),
+        )
+        .await?;
+    println!("\nCreated repo: {}", repo_url.url);
+
+    api.update_repo_settings(
+        &UpdateRepoParams::builder()
+            .repo_id(&repo_name)
+            .description("Temporary example repo")
+            .build(),
+    )
+    .await?;
+    println!("Updated repo description");
+
+    let new_name = format!("{}/example-repo-renamed-{unique}", user.username);
+    let moved = api
+        .move_repo(
+            &MoveRepoParams::builder()
+                .from_id(&repo_name)
+                .to_id(&new_name)
+                .build(),
+        )
+        .await?;
+    println!("Moved repo to: {}", moved.url);
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&new_name)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Deleted repo");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/spaces.rs
+++ b/huggingface_hub/examples/spaces.rs
@@ -1,0 +1,104 @@
+//! Space operations: runtime info, secrets, variables, and lifecycle management.
+//!
+//! Requires HF_TOKEN and the "spaces" feature.
+//! Run: cargo run -p huggingface-hub --features spaces --example spaces
+
+use huggingface_hub::{
+    AddSpaceSecretParams, AddSpaceVariableParams, CreateRepoParams, DeleteRepoParams,
+    DeleteSpaceSecretParams, DeleteSpaceVariableParams, GetSpaceRuntimeParams, HfApi,
+    PauseSpaceParams, RepoType, RestartSpaceParams,
+};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let runtime = api
+        .get_space_runtime(
+            &GetSpaceRuntimeParams::builder()
+                .repo_id("huggingface/transformers-benchmarks")
+                .build(),
+        )
+        .await?;
+    println!("Space runtime: {runtime:?}");
+
+    // --- Write operations (creates real resources on the Hub) ---
+
+    let user = api.whoami().await?;
+    let unique = std::process::id();
+    let space_name = format!("{}/example-space-{unique}", user.username);
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&space_name)
+            .repo_type(RepoType::Space)
+            .private(true)
+            .space_sdk("static")
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("\nCreated test space: {space_name}");
+
+    api.add_space_secret(
+        &AddSpaceSecretParams::builder()
+            .repo_id(&space_name)
+            .key("EXAMPLE_SECRET")
+            .value("secret-value")
+            .build(),
+    )
+    .await?;
+    println!("Added secret: EXAMPLE_SECRET");
+
+    api.delete_space_secret(
+        &DeleteSpaceSecretParams::builder()
+            .repo_id(&space_name)
+            .key("EXAMPLE_SECRET")
+            .build(),
+    )
+    .await?;
+    println!("Deleted secret: EXAMPLE_SECRET");
+
+    api.add_space_variable(
+        &AddSpaceVariableParams::builder()
+            .repo_id(&space_name)
+            .key("EXAMPLE_VAR")
+            .value("var-value")
+            .build(),
+    )
+    .await?;
+    println!("Added variable: EXAMPLE_VAR");
+
+    api.delete_space_variable(
+        &DeleteSpaceVariableParams::builder()
+            .repo_id(&space_name)
+            .key("EXAMPLE_VAR")
+            .build(),
+    )
+    .await?;
+    println!("Deleted variable: EXAMPLE_VAR");
+
+    let paused = api
+        .pause_space(&PauseSpaceParams::builder().repo_id(&space_name).build())
+        .await?;
+    println!("Paused space: {paused:?}");
+
+    let restarted = api
+        .restart_space(&RestartSpaceParams::builder().repo_id(&space_name).build())
+        .await?;
+    println!("Restarted space: {restarted:?}");
+
+    api.delete_repo(
+        &DeleteRepoParams::builder()
+            .repo_id(&space_name)
+            .repo_type(RepoType::Space)
+            .missing_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("Cleaned up test space");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/users.rs
+++ b/huggingface_hub/examples/users.rs
@@ -1,0 +1,68 @@
+//! User operations: authentication, user info, and social features.
+//!
+//! Requires HF_TOKEN environment variable.
+//! Run: cargo run -p huggingface-hub --example users
+
+use futures::StreamExt;
+use huggingface_hub::HfApi;
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    api.auth_check().await?;
+    println!("Token is valid");
+
+    let me = api.whoami().await?;
+    println!(
+        "Logged in as: {} (type: {:?}, pro: {:?})",
+        me.username, me.user_type, me.is_pro
+    );
+
+    let user = api.get_user_overview("julien-c").await?;
+    println!(
+        "\nUser overview: {} (fullname: {:?})",
+        user.username, user.fullname
+    );
+
+    let org = api.get_organization_overview("huggingface").await?;
+    println!("Org overview: {} (fullname: {:?})", org.name, org.fullname);
+
+    let followers = api.list_user_followers("julien-c");
+    futures::pin_mut!(followers);
+    println!("\nFollowers of julien-c:");
+    let mut count = 0;
+    while let Some(Ok(user)) = followers.next().await {
+        println!("  - {}", user.username);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    let following = api.list_user_following("julien-c");
+    futures::pin_mut!(following);
+    println!("\njulien-c is following:");
+    let mut count = 0;
+    while let Some(Ok(user)) = following.next().await {
+        println!("  - {}", user.username);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    let members = api.list_organization_members("huggingface");
+    futures::pin_mut!(members);
+    println!("\nMembers of huggingface:");
+    let mut count = 0;
+    while let Some(Ok(member)) = members.next().await {
+        println!("  - {}", member.username);
+        count += 1;
+        if count >= 3 {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/huggingface_hub/examples/webhooks.rs
+++ b/huggingface_hub/examples/webhooks.rs
@@ -1,0 +1,61 @@
+//! Webhook operations: list, create, update, enable/disable, and delete.
+//!
+//! Requires HF_TOKEN and the "webhooks" feature.
+//! Run: cargo run -p huggingface-hub --features webhooks --example webhooks
+
+use huggingface_hub::{CreateWebhookParams, HfApi, UpdateWebhookParams};
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+
+    // --- Read operations ---
+
+    let webhooks = api.list_webhooks().await?;
+    println!("Current webhooks: {}", webhooks.len());
+    for wh in &webhooks {
+        println!("  - {:?} -> {:?}", wh.id, wh.url);
+    }
+
+    // --- Write operations ---
+
+    let user = api.whoami().await?;
+    let webhook = api
+        .create_webhook(
+            &CreateWebhookParams::builder()
+                .url("https://example.com/webhook")
+                .watched(vec![serde_json::json!({
+                    "type": "user",
+                    "name": user.username,
+                })])
+                .domains(vec!["repo".to_string()])
+                .build(),
+        )
+        .await?;
+    let webhook_id = webhook.id.as_deref().expect("webhook should have an id");
+    println!("\nCreated webhook: {webhook_id}");
+
+    let fetched = api.get_webhook(webhook_id).await?;
+    println!("Fetched webhook: {:?} -> {:?}", fetched.id, fetched.url);
+
+    let updated = api
+        .update_webhook(
+            &UpdateWebhookParams::builder()
+                .webhook_id(webhook_id)
+                .url("https://example.com/webhook-updated")
+                .build(),
+        )
+        .await?;
+    println!("Updated webhook URL: {:?}", updated.url);
+
+    let disabled = api.disable_webhook(webhook_id).await?;
+    println!("Disabled webhook: {:?}", disabled.disabled);
+
+    let enabled = api.enable_webhook(webhook_id).await?;
+    println!("Enabled webhook: {:?}", enabled.disabled);
+
+    api.delete_webhook(webhook_id).await?;
+    println!("Deleted webhook");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add 13 standalone example files under `huggingface_hub/examples/`, one per API module
- Each example demonstrates all public methods in its module with realistic usage patterns
- Core examples (repo, files, commits, users) require no feature flags
- Feature-gated examples (spaces, collections, discussions, webhooks, jobs, inference_endpoints, access_requests, likes, papers) use `required-features` in Cargo.toml
- Write operations create temporary resources, operate on them, then clean up
- Inference endpoint creation is guarded behind `HF_TEST_IE=1` (costs money)

## Test plan

- [x] `cargo build -p huggingface-hub --examples` — core examples compile
- [x] `cargo build -p huggingface-hub --all-features --examples` — all 13 examples compile
- [x] `cargo +nightly fmt` — formatting clean
- [x] `cargo clippy -p huggingface-hub --all-features --examples -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)