### PR TITLE
chore: add rustfmt.toml and apply nightly formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo +nightly fmt --check
+      - run: cargo +nightly fmt --all --check
 
   clippy:
     name: Lint

--- a/huggingface_hub/examples/access_requests.rs
+++ b/huggingface_hub/examples/access_requests.rs
@@ -3,9 +3,7 @@
 //! Requires HF_TOKEN and the "access_requests" feature.
 //! Run: cargo run -p huggingface-hub --features access_requests --example access_requests
 
-use huggingface_hub::{
-    CreateRepoParams, DeleteRepoParams, HfApi, ListAccessRequestsParams, UpdateRepoParams,
-};
+use huggingface_hub::{CreateRepoParams, DeleteRepoParams, HfApi, ListAccessRequestsParams, UpdateRepoParams};
 
 #[tokio::main]
 async fn main() -> huggingface_hub::Result<()> {
@@ -24,18 +22,11 @@ async fn main() -> huggingface_hub::Result<()> {
     )
     .await?;
 
-    api.update_repo_settings(
-        &UpdateRepoParams::builder()
-            .repo_id(&repo_name)
-            .gated("auto")
-            .build(),
-    )
-    .await?;
+    api.update_repo_settings(&UpdateRepoParams::builder().repo_id(&repo_name).gated("auto").build())
+        .await?;
     println!("Created gated repo: {repo_name}");
 
-    let params = ListAccessRequestsParams::builder()
-        .repo_id(&repo_name)
-        .build();
+    let params = ListAccessRequestsParams::builder().repo_id(&repo_name).build();
 
     let pending = api.list_pending_access_requests(&params).await?;
     println!("Pending requests: {}", pending.len());
@@ -46,13 +37,8 @@ async fn main() -> huggingface_hub::Result<()> {
     let rejected = api.list_rejected_access_requests(&params).await?;
     println!("Rejected requests: {}", rejected.len());
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&repo_name)
-            .missing_ok(true)
-            .build(),
-    )
-    .await?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/huggingface_hub/examples/blocking_read.rs
+++ b/huggingface_hub/examples/blocking_read.rs
@@ -7,9 +7,9 @@
 //! Run: cargo run -p huggingface-hub --features blocking --example blocking_read
 
 use huggingface_hub::{
-    DatasetInfoParams, DownloadFileParams, GetPathsInfoParams, HfApiSync, ListDatasetsParams,
-    ListModelsParams, ListRepoCommitsParams, ListRepoFilesParams, ListRepoTreeParams,
-    ModelInfoParams, RepoExistsParams, RepoTreeEntry, SpaceInfoParams,
+    DatasetInfoParams, DownloadFileParams, GetPathsInfoParams, HfApiSync, ListDatasetsParams, ListModelsParams,
+    ListRepoCommitsParams, ListRepoFilesParams, ListRepoTreeParams, ModelInfoParams, RepoExistsParams, RepoTreeEntry,
+    SpaceInfoParams,
 };
 
 fn main() -> huggingface_hub::Result<()> {
@@ -20,15 +20,8 @@ fn main() -> huggingface_hub::Result<()> {
     let model = api.model_info(&ModelInfoParams::builder().repo_id("gpt2").build())?;
     println!("Model: {} (downloads: {:?})", model.id, model.downloads);
 
-    let dataset = api.dataset_info(
-        &DatasetInfoParams::builder()
-            .repo_id("rajpurkar/squad")
-            .build(),
-    )?;
-    println!(
-        "Dataset: {} (downloads: {:?})",
-        dataset.id, dataset.downloads
-    );
+    let dataset = api.dataset_info(&DatasetInfoParams::builder().repo_id("rajpurkar/squad").build())?;
+    println!("Dataset: {} (downloads: {:?})", dataset.id, dataset.downloads);
 
     let space = api.space_info(
         &SpaceInfoParams::builder()
@@ -62,12 +55,7 @@ fn main() -> huggingface_hub::Result<()> {
         println!("  - {f}");
     }
 
-    let tree = api.list_repo_tree(
-        &ListRepoTreeParams::builder()
-            .repo_id("gpt2")
-            .recursive(true)
-            .build(),
-    )?;
+    let tree = api.list_repo_tree(&ListRepoTreeParams::builder().repo_id("gpt2").recursive(true).build())?;
     println!("\nTree entries in gpt2:");
     for entry in tree.iter().take(5) {
         match entry {
@@ -96,11 +84,7 @@ fn main() -> huggingface_hub::Result<()> {
 
     // --- Commits ---
 
-    let commits = api.list_repo_commits(
-        &ListRepoCommitsParams::builder()
-            .repo_id("openai-community/gpt2")
-            .build(),
-    )?;
+    let commits = api.list_repo_commits(&ListRepoCommitsParams::builder().repo_id("openai-community/gpt2").build())?;
     println!("\nRecent commits on gpt2 ({} total):", commits.len());
     for c in commits.iter().take(3) {
         println!("  - {} {}", &c.id[..8], c.title);

--- a/huggingface_hub/examples/blocking_write.rs
+++ b/huggingface_hub/examples/blocking_write.rs
@@ -6,10 +6,9 @@
 //! Run: cargo run -p huggingface-hub --features blocking --example blocking_write
 
 use huggingface_hub::{
-    AddSource, CommitOperation, CreateBranchParams, CreateCommitParams, CreateRepoParams,
-    CreateTagParams, DeleteBranchParams, DeleteFileParams, DeleteRepoParams, DeleteTagParams,
-    DownloadFileParams, FileExistsParams, HfApiSync, ListRepoFilesParams, ListRepoRefsParams,
-    UploadFileParams, UploadFolderParams,
+    AddSource, CommitOperation, CreateBranchParams, CreateCommitParams, CreateRepoParams, CreateTagParams,
+    DeleteBranchParams, DeleteFileParams, DeleteRepoParams, DeleteTagParams, DownloadFileParams, FileExistsParams,
+    HfApiSync, ListRepoFilesParams, ListRepoRefsParams, UploadFileParams, UploadFolderParams,
 };
 
 fn main() -> huggingface_hub::Result<()> {
@@ -101,12 +100,7 @@ fn main() -> huggingface_hub::Result<()> {
 
     // --- Branch and tag management ---
 
-    api.create_branch(
-        &CreateBranchParams::builder()
-            .repo_id(&repo_name)
-            .branch("dev")
-            .build(),
-    )?;
+    api.create_branch(&CreateBranchParams::builder().repo_id(&repo_name).branch("dev").build())?;
     println!("\nCreated branch 'dev'");
 
     api.create_tag(
@@ -119,27 +113,11 @@ fn main() -> huggingface_hub::Result<()> {
     println!("Created tag 'v1.0'");
 
     let refs = api.list_repo_refs(&ListRepoRefsParams::builder().repo_id(&repo_name).build())?;
-    println!(
-        "Branches: {:?}",
-        refs.branches.iter().map(|b| &b.name).collect::<Vec<_>>()
-    );
-    println!(
-        "Tags: {:?}",
-        refs.tags.iter().map(|t| &t.name).collect::<Vec<_>>()
-    );
+    println!("Branches: {:?}", refs.branches.iter().map(|b| &b.name).collect::<Vec<_>>());
+    println!("Tags: {:?}", refs.tags.iter().map(|t| &t.name).collect::<Vec<_>>());
 
-    api.delete_tag(
-        &DeleteTagParams::builder()
-            .repo_id(&repo_name)
-            .tag("v1.0")
-            .build(),
-    )?;
-    api.delete_branch(
-        &DeleteBranchParams::builder()
-            .repo_id(&repo_name)
-            .branch("dev")
-            .build(),
-    )?;
+    api.delete_tag(&DeleteTagParams::builder().repo_id(&repo_name).tag("v1.0").build())?;
+    api.delete_branch(&DeleteBranchParams::builder().repo_id(&repo_name).branch("dev").build())?;
     println!("Cleaned up branch and tag");
 
     // --- Delete a file ---
@@ -150,22 +128,12 @@ fn main() -> huggingface_hub::Result<()> {
             .path_in_repo("hello.txt")
             .build(),
     )?;
-    let gone = !api.file_exists(
-        &FileExistsParams::builder()
-            .repo_id(&repo_name)
-            .filename("hello.txt")
-            .build(),
-    )?;
+    let gone = !api.file_exists(&FileExistsParams::builder().repo_id(&repo_name).filename("hello.txt").build())?;
     println!("\nhello.txt deleted: {gone}");
 
     // --- Clean up ---
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&repo_name)
-            .missing_ok(true)
-            .build(),
-    )?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())?;
     println!("Deleted repo");
 
     Ok(())

--- a/huggingface_hub/examples/collections.rs
+++ b/huggingface_hub/examples/collections.rs
@@ -4,9 +4,8 @@
 //! Run: cargo run -p huggingface-hub --features collections --example collections
 
 use huggingface_hub::{
-    AddCollectionItemParams, CreateCollectionParams, DeleteCollectionItemParams,
-    DeleteCollectionParams, GetCollectionParams, HfApi, ListCollectionsParams,
-    UpdateCollectionItemParams, UpdateCollectionMetadataParams,
+    AddCollectionItemParams, CreateCollectionParams, DeleteCollectionItemParams, DeleteCollectionParams,
+    GetCollectionParams, HfApi, ListCollectionsParams, UpdateCollectionItemParams, UpdateCollectionMetadataParams,
 };
 
 #[tokio::main]
@@ -16,12 +15,7 @@ async fn main() -> huggingface_hub::Result<()> {
     // --- Read operations ---
 
     let collections = api
-        .list_collections(
-            &ListCollectionsParams::builder()
-                .owner("huggingface")
-                .limit(3_usize)
-                .build(),
-        )
+        .list_collections(&ListCollectionsParams::builder().owner("huggingface").limit(3_usize).build())
         .await?;
     println!("Collections by huggingface:");
     for c in &collections {
@@ -32,11 +26,7 @@ async fn main() -> huggingface_hub::Result<()> {
         let detail = api
             .get_collection(&GetCollectionParams::builder().slug(&first.slug).build())
             .await?;
-        println!(
-            "\nCollection detail: {} ({} items)",
-            detail.slug,
-            detail.items.len()
-        );
+        println!("\nCollection detail: {} ({} items)", detail.slug, detail.items.len());
     }
 
     // --- Write operations ---
@@ -99,12 +89,8 @@ async fn main() -> huggingface_hub::Result<()> {
     .await?;
     println!("Deleted item from collection");
 
-    api.delete_collection(
-        &DeleteCollectionParams::builder()
-            .slug(&collection.slug)
-            .build(),
-    )
-    .await?;
+    api.delete_collection(&DeleteCollectionParams::builder().slug(&collection.slug).build())
+        .await?;
     println!("Deleted collection");
 
     Ok(())

--- a/huggingface_hub/examples/commits.rs
+++ b/huggingface_hub/examples/commits.rs
@@ -5,9 +5,8 @@
 
 use futures::StreamExt;
 use huggingface_hub::{
-    CreateBranchParams, CreateRepoParams, CreateTagParams, DeleteBranchParams, DeleteRepoParams,
-    DeleteTagParams, GetCommitDiffParams, GetRawDiffParams, HfApi, ListRepoCommitsParams,
-    ListRepoRefsParams,
+    CreateBranchParams, CreateRepoParams, CreateTagParams, DeleteBranchParams, DeleteRepoParams, DeleteTagParams,
+    GetCommitDiffParams, GetRawDiffParams, HfApi, ListRepoCommitsParams, ListRepoRefsParams,
 };
 
 #[tokio::main]
@@ -16,8 +15,7 @@ async fn main() -> huggingface_hub::Result<()> {
 
     // --- Read operations ---
 
-    let commits_stream =
-        api.list_repo_commits(&ListRepoCommitsParams::builder().repo_id("gpt2").build());
+    let commits_stream = api.list_repo_commits(&ListRepoCommitsParams::builder().repo_id("gpt2").build());
     futures::pin_mut!(commits_stream);
     println!("Recent commits in gpt2:");
     let mut first_two_ids: Vec<String> = Vec::new();
@@ -48,23 +46,13 @@ async fn main() -> huggingface_hub::Result<()> {
     if first_two_ids.len() == 2 {
         let compare = format!("{}..{}", first_two_ids[1], first_two_ids[0]);
         let diff = api
-            .get_commit_diff(
-                &GetCommitDiffParams::builder()
-                    .repo_id("gpt2")
-                    .compare(&compare)
-                    .build(),
-            )
+            .get_commit_diff(&GetCommitDiffParams::builder().repo_id("gpt2").compare(&compare).build())
             .await?;
         println!("\nDiff ({compare}):");
         println!("  {} chars", diff.len());
 
         let raw_diff = api
-            .get_raw_diff(
-                &GetRawDiffParams::builder()
-                    .repo_id("gpt2")
-                    .compare(&compare)
-                    .build(),
-            )
+            .get_raw_diff(&GetRawDiffParams::builder().repo_id("gpt2").compare(&compare).build())
             .await?;
         println!("Raw diff: {} chars", raw_diff.len());
     }
@@ -113,22 +101,12 @@ async fn main() -> huggingface_hub::Result<()> {
     .await?;
     println!("Created tag: v0.1.0");
 
-    api.delete_tag(
-        &DeleteTagParams::builder()
-            .repo_id(&repo_name)
-            .tag("v0.1.0")
-            .build(),
-    )
-    .await?;
+    api.delete_tag(&DeleteTagParams::builder().repo_id(&repo_name).tag("v0.1.0").build())
+        .await?;
     println!("Deleted tag: v0.1.0");
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&repo_name)
-            .missing_ok(true)
-            .build(),
-    )
-    .await?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/huggingface_hub/examples/discussions.rs
+++ b/huggingface_hub/examples/discussions.rs
@@ -4,9 +4,8 @@
 //! Run: cargo run -p huggingface-hub --features discussions --example discussions
 
 use huggingface_hub::{
-    ChangeDiscussionStatusParams, CommentDiscussionParams, CreateDiscussionParams,
-    CreateRepoParams, DeleteRepoParams, EditDiscussionCommentParams, GetDiscussionDetailsParams,
-    GetRepoDiscussionsParams, HfApi, RenameDiscussionParams,
+    ChangeDiscussionStatusParams, CommentDiscussionParams, CreateDiscussionParams, CreateRepoParams, DeleteRepoParams,
+    EditDiscussionCommentParams, GetDiscussionDetailsParams, GetRepoDiscussionsParams, HfApi, RenameDiscussionParams,
 };
 
 #[tokio::main]
@@ -18,11 +17,7 @@ async fn main() -> huggingface_hub::Result<()> {
     let discussions = api
         .get_repo_discussions(&GetRepoDiscussionsParams::builder().repo_id("gpt2").build())
         .await?;
-    println!(
-        "Discussions in gpt2: {} (total: {:?})",
-        discussions.discussions.len(),
-        discussions.count
-    );
+    println!("Discussions in gpt2: {} (total: {:?})", discussions.discussions.len(), discussions.count);
 
     if let Some(first) = discussions.discussions.first() {
         let details = api
@@ -33,10 +28,7 @@ async fn main() -> huggingface_hub::Result<()> {
                     .build(),
             )
             .await?;
-        println!(
-            "Discussion #{}: {:?} (status: {:?})",
-            details.num, details.title, details.status
-        );
+        println!("Discussion #{}: {:?} (status: {:?})", details.num, details.title, details.status);
     }
 
     // --- Write operations ---
@@ -111,13 +103,8 @@ async fn main() -> huggingface_hub::Result<()> {
     .await?;
     println!("Closed discussion");
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&repo_name)
-            .missing_ok(true)
-            .build(),
-    )
-    .await?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/huggingface_hub/examples/files.rs
+++ b/huggingface_hub/examples/files.rs
@@ -5,9 +5,9 @@
 
 use futures::StreamExt;
 use huggingface_hub::{
-    AddSource, CommitOperation, CreateCommitParams, CreateRepoParams, DeleteFileParams,
-    DeleteFolderParams, DeleteRepoParams, DownloadFileParams, GetPathsInfoParams, HfApi,
-    ListRepoFilesParams, ListRepoTreeParams, RepoTreeEntry, UploadFileParams, UploadFolderParams,
+    AddSource, CommitOperation, CreateCommitParams, CreateRepoParams, DeleteFileParams, DeleteFolderParams,
+    DeleteRepoParams, DownloadFileParams, GetPathsInfoParams, HfApi, ListRepoFilesParams, ListRepoTreeParams,
+    RepoTreeEntry, UploadFileParams, UploadFolderParams,
 };
 #[tokio::main]
 async fn main() -> huggingface_hub::Result<()> {
@@ -23,12 +23,7 @@ async fn main() -> huggingface_hub::Result<()> {
         println!("  - {f}");
     }
 
-    let tree_stream = api.list_repo_tree(
-        &ListRepoTreeParams::builder()
-            .repo_id("gpt2")
-            .recursive(true)
-            .build(),
-    );
+    let tree_stream = api.list_repo_tree(&ListRepoTreeParams::builder().repo_id("gpt2").recursive(true).build());
     futures::pin_mut!(tree_stream);
     println!("\nTree entries in gpt2:");
     let mut count = 0;
@@ -142,22 +137,12 @@ async fn main() -> huggingface_hub::Result<()> {
     .await?;
     println!("Deleted hello.txt");
 
-    api.delete_folder(
-        &DeleteFolderParams::builder()
-            .repo_id(&repo_name)
-            .path_in_repo("data")
-            .build(),
-    )
-    .await?;
+    api.delete_folder(&DeleteFolderParams::builder().repo_id(&repo_name).path_in_repo("data").build())
+        .await?;
     println!("Deleted data/ folder");
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&repo_name)
-            .missing_ok(true)
-            .build(),
-    )
-    .await?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/huggingface_hub/examples/inference_endpoints.rs
+++ b/huggingface_hub/examples/inference_endpoints.rs
@@ -7,10 +7,9 @@
 //! Run: cargo run -p huggingface-hub --features inference_endpoints --example inference_endpoints
 
 use huggingface_hub::{
-    CreateInferenceEndpointParams, DeleteInferenceEndpointParams, GetInferenceEndpointParams,
-    HfApi, ListInferenceEndpointsParams, PauseInferenceEndpointParams,
-    ResumeInferenceEndpointParams, ScaleToZeroInferenceEndpointParams,
-    UpdateInferenceEndpointParams,
+    CreateInferenceEndpointParams, DeleteInferenceEndpointParams, GetInferenceEndpointParams, HfApi,
+    ListInferenceEndpointsParams, PauseInferenceEndpointParams, ResumeInferenceEndpointParams,
+    ScaleToZeroInferenceEndpointParams, UpdateInferenceEndpointParams,
 };
 
 #[tokio::main]
@@ -68,38 +67,22 @@ async fn main() -> huggingface_hub::Result<()> {
     println!("Updated endpoint: {:?}", updated);
 
     let paused = api
-        .pause_inference_endpoint(
-            &PauseInferenceEndpointParams::builder()
-                .name(&ep_name)
-                .build(),
-        )
+        .pause_inference_endpoint(&PauseInferenceEndpointParams::builder().name(&ep_name).build())
         .await?;
     println!("Paused endpoint: {:?}", paused);
 
     let resumed = api
-        .resume_inference_endpoint(
-            &ResumeInferenceEndpointParams::builder()
-                .name(&ep_name)
-                .build(),
-        )
+        .resume_inference_endpoint(&ResumeInferenceEndpointParams::builder().name(&ep_name).build())
         .await?;
     println!("Resumed endpoint: {:?}", resumed);
 
     let scaled = api
-        .scale_to_zero_inference_endpoint(
-            &ScaleToZeroInferenceEndpointParams::builder()
-                .name(&ep_name)
-                .build(),
-        )
+        .scale_to_zero_inference_endpoint(&ScaleToZeroInferenceEndpointParams::builder().name(&ep_name).build())
         .await?;
     println!("Scaled to zero: {:?}", scaled);
 
-    api.delete_inference_endpoint(
-        &DeleteInferenceEndpointParams::builder()
-            .name(&ep_name)
-            .build(),
-    )
-    .await?;
+    api.delete_inference_endpoint(&DeleteInferenceEndpointParams::builder().name(&ep_name).build())
+        .await?;
     println!("Deleted endpoint");
 
     Ok(())

--- a/huggingface_hub/examples/likes.rs
+++ b/huggingface_hub/examples/likes.rs
@@ -12,19 +12,14 @@ async fn main() -> huggingface_hub::Result<()> {
 
     let user = api.whoami().await?;
     let liked = api
-        .list_liked_repos(
-            &ListLikedReposParams::builder()
-                .username(&user.username)
-                .build(),
-        )
+        .list_liked_repos(&ListLikedReposParams::builder().username(&user.username).build())
         .await?;
     println!("Liked repos by {}:", user.username);
     for repo in liked.iter().take(5) {
         println!("  - {:?}", repo);
     }
 
-    let likers_stream =
-        api.list_repo_likers(&ListRepoLikersParams::builder().repo_id("gpt2").build());
+    let likers_stream = api.list_repo_likers(&ListRepoLikersParams::builder().repo_id("gpt2").build());
     futures::pin_mut!(likers_stream);
     println!("\nLikers of gpt2:");
     let mut count = 0;
@@ -36,12 +31,10 @@ async fn main() -> huggingface_hub::Result<()> {
         }
     }
 
-    api.like(&LikeParams::builder().repo_id("gpt2").build())
-        .await?;
+    api.like(&LikeParams::builder().repo_id("gpt2").build()).await?;
     println!("\nLiked gpt2");
 
-    api.unlike(&LikeParams::builder().repo_id("gpt2").build())
-        .await?;
+    api.unlike(&LikeParams::builder().repo_id("gpt2").build()).await?;
     println!("Unliked gpt2");
 
     Ok(())

--- a/huggingface_hub/examples/papers.rs
+++ b/huggingface_hub/examples/papers.rs
@@ -10,12 +10,7 @@ async fn main() -> huggingface_hub::Result<()> {
     let api = HfApi::new()?;
 
     let results = api
-        .list_papers(
-            &ListPapersParams::builder()
-                .query("transformers")
-                .limit(3_usize)
-                .build(),
-        )
+        .list_papers(&ListPapersParams::builder().query("transformers").limit(3_usize).build())
         .await?;
     println!("Paper search results for 'transformers':");
     for paper in &results {
@@ -31,9 +26,7 @@ async fn main() -> huggingface_hub::Result<()> {
     }
 
     if let Some(first) = results.first().and_then(|r| r.paper.as_ref()) {
-        let info = api
-            .paper_info(&PaperInfoParams::builder().paper_id(&first.id).build())
-            .await?;
+        let info = api.paper_info(&PaperInfoParams::builder().paper_id(&first.id).build()).await?;
         println!("\nPaper info: {:?}", info);
     }
 

--- a/huggingface_hub/examples/repo.rs
+++ b/huggingface_hub/examples/repo.rs
@@ -5,9 +5,9 @@
 
 use futures::StreamExt;
 use huggingface_hub::{
-    CreateRepoParams, DatasetInfoParams, DeleteRepoParams, FileExistsParams, HfApi,
-    ListDatasetsParams, ListModelsParams, ListSpacesParams, ModelInfoParams, MoveRepoParams,
-    RepoExistsParams, RevisionExistsParams, SpaceInfoParams, UpdateRepoParams,
+    CreateRepoParams, DatasetInfoParams, DeleteRepoParams, FileExistsParams, HfApi, ListDatasetsParams,
+    ListModelsParams, ListSpacesParams, ModelInfoParams, MoveRepoParams, RepoExistsParams, RevisionExistsParams,
+    SpaceInfoParams, UpdateRepoParams,
 };
 
 #[tokio::main]
@@ -16,22 +16,13 @@ async fn main() -> huggingface_hub::Result<()> {
 
     // --- Read operations ---
 
-    let model = api
-        .model_info(&ModelInfoParams::builder().repo_id("gpt2").build())
-        .await?;
+    let model = api.model_info(&ModelInfoParams::builder().repo_id("gpt2").build()).await?;
     println!("Model: {} (downloads: {:?})", model.id, model.downloads);
 
     let dataset = api
-        .dataset_info(
-            &DatasetInfoParams::builder()
-                .repo_id("rajpurkar/squad")
-                .build(),
-        )
+        .dataset_info(&DatasetInfoParams::builder().repo_id("rajpurkar/squad").build())
         .await?;
-    println!(
-        "Dataset: {} (downloads: {:?})",
-        dataset.id, dataset.downloads
-    );
+    println!("Dataset: {} (downloads: {:?})", dataset.id, dataset.downloads);
 
     let space = api
         .space_info(
@@ -42,28 +33,16 @@ async fn main() -> huggingface_hub::Result<()> {
         .await?;
     println!("Space: {} (sdk: {:?})", space.id, space.sdk);
 
-    let exists = api
-        .repo_exists(&RepoExistsParams::builder().repo_id("gpt2").build())
-        .await?;
+    let exists = api.repo_exists(&RepoExistsParams::builder().repo_id("gpt2").build()).await?;
     println!("gpt2 exists: {exists}");
 
     let rev_exists = api
-        .revision_exists(
-            &RevisionExistsParams::builder()
-                .repo_id("gpt2")
-                .revision("main")
-                .build(),
-        )
+        .revision_exists(&RevisionExistsParams::builder().repo_id("gpt2").revision("main").build())
         .await?;
     println!("gpt2@main exists: {rev_exists}");
 
     let file_exists = api
-        .file_exists(
-            &FileExistsParams::builder()
-                .repo_id("gpt2")
-                .filename("config.json")
-                .build(),
-        )
+        .file_exists(&FileExistsParams::builder().repo_id("gpt2").filename("config.json").build())
         .await?;
     println!("gpt2/config.json exists: {file_exists}");
 
@@ -131,22 +110,12 @@ async fn main() -> huggingface_hub::Result<()> {
 
     let new_name = format!("{}/example-repo-renamed-{unique}", user.username);
     let moved = api
-        .move_repo(
-            &MoveRepoParams::builder()
-                .from_id(&repo_name)
-                .to_id(&new_name)
-                .build(),
-        )
+        .move_repo(&MoveRepoParams::builder().from_id(&repo_name).to_id(&new_name).build())
         .await?;
     println!("Moved repo to: {}", moved.url);
 
-    api.delete_repo(
-        &DeleteRepoParams::builder()
-            .repo_id(&new_name)
-            .missing_ok(true)
-            .build(),
-    )
-    .await?;
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&new_name).missing_ok(true).build())
+        .await?;
     println!("Deleted repo");
 
     Ok(())

--- a/huggingface_hub/examples/spaces.rs
+++ b/huggingface_hub/examples/spaces.rs
@@ -4,9 +4,8 @@
 //! Run: cargo run -p huggingface-hub --features spaces --example spaces
 
 use huggingface_hub::{
-    AddSpaceSecretParams, AddSpaceVariableParams, CreateRepoParams, DeleteRepoParams,
-    DeleteSpaceSecretParams, DeleteSpaceVariableParams, GetSpaceRuntimeParams, HfApi,
-    PauseSpaceParams, RepoType, RestartSpaceParams,
+    AddSpaceSecretParams, AddSpaceVariableParams, CreateRepoParams, DeleteRepoParams, DeleteSpaceSecretParams,
+    DeleteSpaceVariableParams, GetSpaceRuntimeParams, HfApi, PauseSpaceParams, RepoType, RestartSpaceParams,
 };
 
 #[tokio::main]

--- a/huggingface_hub/examples/users.rs
+++ b/huggingface_hub/examples/users.rs
@@ -14,16 +14,10 @@ async fn main() -> huggingface_hub::Result<()> {
     println!("Token is valid");
 
     let me = api.whoami().await?;
-    println!(
-        "Logged in as: {} (type: {:?}, pro: {:?})",
-        me.username, me.user_type, me.is_pro
-    );
+    println!("Logged in as: {} (type: {:?}, pro: {:?})", me.username, me.user_type, me.is_pro);
 
     let user = api.get_user_overview("julien-c").await?;
-    println!(
-        "\nUser overview: {} (fullname: {:?})",
-        user.username, user.fullname
-    );
+    println!("\nUser overview: {} (fullname: {:?})", user.username, user.fullname);
 
     let org = api.get_organization_overview("huggingface").await?;
     println!("Org overview: {} (fullname: {:?})", org.name, org.fullname);

--- a/huggingface_hub/src/api/access_requests.rs
+++ b/huggingface_hub/src/api/access_requests.rs
@@ -1,8 +1,6 @@
 use crate::client::HfApi;
 use crate::error::Result;
-use crate::types::{
-    AccessRequest, GrantAccessParams, HandleAccessRequestParams, ListAccessRequestsParams,
-};
+use crate::types::{AccessRequest, GrantAccessParams, HandleAccessRequestParams, ListAccessRequestsParams};
 
 impl HfApi {
     async fn list_access_requests_by_status(
@@ -10,60 +8,28 @@ impl HfApi {
         params: &ListAccessRequestsParams,
         status: &str,
     ) -> Result<Vec<AccessRequest>> {
-        let url = format!(
-            "{}/user-access-request/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            status
-        );
+        let url = format!("{}/user-access-request/{}", self.api_url(params.repo_type, &params.repo_id), status);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn list_pending_access_requests(
-        &self,
-        params: &ListAccessRequestsParams,
-    ) -> Result<Vec<AccessRequest>> {
+    pub async fn list_pending_access_requests(&self, params: &ListAccessRequestsParams) -> Result<Vec<AccessRequest>> {
         self.list_access_requests_by_status(params, "pending").await
     }
 
-    pub async fn list_accepted_access_requests(
-        &self,
-        params: &ListAccessRequestsParams,
-    ) -> Result<Vec<AccessRequest>> {
-        self.list_access_requests_by_status(params, "accepted")
-            .await
+    pub async fn list_accepted_access_requests(&self, params: &ListAccessRequestsParams) -> Result<Vec<AccessRequest>> {
+        self.list_access_requests_by_status(params, "accepted").await
     }
 
-    pub async fn list_rejected_access_requests(
-        &self,
-        params: &ListAccessRequestsParams,
-    ) -> Result<Vec<AccessRequest>> {
-        self.list_access_requests_by_status(params, "rejected")
-            .await
+    pub async fn list_rejected_access_requests(&self, params: &ListAccessRequestsParams) -> Result<Vec<AccessRequest>> {
+        self.list_access_requests_by_status(params, "rejected").await
     }
 
-    async fn handle_access_request(
-        &self,
-        params: &HandleAccessRequestParams,
-        status: &str,
-    ) -> Result<()> {
-        let url = format!(
-            "{}/user-access-request/handle",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+    async fn handle_access_request(&self, params: &HandleAccessRequestParams, status: &str) -> Result<()> {
+        let url = format!("{}/user-access-request/handle", self.api_url(params.repo_type, &params.repo_id));
         let body = serde_json::json!({
             "user": params.user,
             "status": status,
@@ -76,12 +42,8 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
@@ -98,10 +60,7 @@ impl HfApi {
     }
 
     pub async fn grant_access(&self, params: &GrantAccessParams) -> Result<()> {
-        let url = format!(
-            "{}/user-access-request/grant",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+        let url = format!("{}/user-access-request/grant", self.api_url(params.repo_type, &params.repo_id));
         let body = serde_json::json!({ "user": params.user });
         let response = self
             .inner
@@ -111,12 +70,8 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 }

--- a/huggingface_hub/src/api/collections.rs
+++ b/huggingface_hub/src/api/collections.rs
@@ -1,31 +1,22 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    AddCollectionItemParams, Collection, CollectionItem, CreateCollectionParams,
-    DeleteCollectionItemParams, DeleteCollectionParams, GetCollectionParams, ListCollectionsParams,
-    UpdateCollectionItemParams, UpdateCollectionMetadataParams,
+    AddCollectionItemParams, Collection, CollectionItem, CreateCollectionParams, DeleteCollectionItemParams,
+    DeleteCollectionParams, GetCollectionParams, ListCollectionsParams, UpdateCollectionItemParams,
+    UpdateCollectionMetadataParams,
 };
 
 impl HfApi {
     pub async fn get_collection(&self, params: &GetCollectionParams) -> Result<Collection> {
         let url = format!("{}/api/collections/{}", self.inner.endpoint, params.slug);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn list_collections(
-        &self,
-        params: &ListCollectionsParams,
-    ) -> Result<Vec<Collection>> {
+    pub async fn list_collections(&self, params: &ListCollectionsParams) -> Result<Vec<Collection>> {
         let url = format!("{}/api/collections", self.inner.endpoint);
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref owner) = params.owner {
@@ -83,10 +74,7 @@ impl HfApi {
         Ok(response.json().await?)
     }
 
-    pub async fn update_collection_metadata(
-        &self,
-        params: &UpdateCollectionMetadataParams,
-    ) -> Result<Collection> {
+    pub async fn update_collection_metadata(&self, params: &UpdateCollectionMetadataParams) -> Result<Collection> {
         let url = format!("{}/api/collections/{}", self.inner.endpoint, params.slug);
         let mut body = serde_json::Map::new();
         if let Some(ref title) = params.title {
@@ -120,13 +108,7 @@ impl HfApi {
 
     pub async fn delete_collection(&self, params: &DeleteCollectionParams) -> Result<()> {
         let url = format!("{}/api/collections/{}", self.inner.endpoint, params.slug);
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
         if response.status().as_u16() == 404 && params.missing_ok {
             return Ok(());
         }
@@ -135,14 +117,8 @@ impl HfApi {
         Ok(())
     }
 
-    pub async fn add_collection_item(
-        &self,
-        params: &AddCollectionItemParams,
-    ) -> Result<Collection> {
-        let url = format!(
-            "{}/api/collections/{}/items",
-            self.inner.endpoint, params.slug
-        );
+    pub async fn add_collection_item(&self, params: &AddCollectionItemParams) -> Result<Collection> {
+        let url = format!("{}/api/collections/{}/items", self.inner.endpoint, params.slug);
         let mut body = serde_json::json!({
             "item_id": params.item_id,
             "item_type": params.item_type,
@@ -169,14 +145,8 @@ impl HfApi {
         Ok(response.json().await?)
     }
 
-    pub async fn update_collection_item(
-        &self,
-        params: &UpdateCollectionItemParams,
-    ) -> Result<CollectionItem> {
-        let url = format!(
-            "{}/api/collections/{}/items/{}",
-            self.inner.endpoint, params.slug, params.item_object_id
-        );
+    pub async fn update_collection_item(&self, params: &UpdateCollectionItemParams) -> Result<CollectionItem> {
+        let url = format!("{}/api/collections/{}/items/{}", self.inner.endpoint, params.slug, params.item_object_id);
         let mut body = serde_json::Map::new();
         if let Some(ref note) = params.note {
             body.insert("note".into(), serde_json::json!(note));
@@ -199,17 +169,8 @@ impl HfApi {
     }
 
     pub async fn delete_collection_item(&self, params: &DeleteCollectionItemParams) -> Result<()> {
-        let url = format!(
-            "{}/api/collections/{}/items/{}",
-            self.inner.endpoint, params.slug, params.item_object_id
-        );
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/collections/{}/items/{}", self.inner.endpoint, params.slug, params.item_object_id);
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(())

--- a/huggingface_hub/src/api/commits.rs
+++ b/huggingface_hub/src/api/commits.rs
@@ -1,29 +1,20 @@
+use futures::Stream;
+use url::Url;
+
 use crate::client::HfApi;
 use crate::constants;
 use crate::error::Result;
 use crate::types::{
-    CreateBranchParams, CreateTagParams, DeleteBranchParams, DeleteTagParams, GetCommitDiffParams,
-    GetRawDiffParams, GitCommitInfo, GitRefs, ListRepoCommitsParams, ListRepoRefsParams,
+    CreateBranchParams, CreateTagParams, DeleteBranchParams, DeleteTagParams, GetCommitDiffParams, GetRawDiffParams,
+    GitCommitInfo, GitRefs, ListRepoCommitsParams, ListRepoRefsParams,
 };
-use futures::Stream;
-use url::Url;
 
 impl HfApi {
     /// List commits in a repository.
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/commits/{revision}
-    pub fn list_repo_commits(
-        &self,
-        params: &ListRepoCommitsParams,
-    ) -> impl Stream<Item = Result<GitCommitInfo>> + '_ {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url_str = format!(
-            "{}/commits/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            revision
-        );
+    pub fn list_repo_commits(&self, params: &ListRepoCommitsParams) -> impl Stream<Item = Result<GitCommitInfo>> + '_ {
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url_str = format!("{}/commits/{}", self.api_url(params.repo_type, &params.repo_id), revision);
         let url = Url::parse(&url_str).unwrap();
         self.paginate(url, vec![])
     }
@@ -47,11 +38,7 @@ impl HfApi {
             .await?;
 
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
@@ -60,26 +47,12 @@ impl HfApi {
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/compare/{compare}
     /// `compare` is in the format "revA..revB"
     pub async fn get_commit_diff(&self, params: &GetCommitDiffParams) -> Result<String> {
-        let url = format!(
-            "{}/compare/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.compare
-        );
+        let url = format!("{}/compare/{}", self.api_url(params.repo_type, &params.repo_id), params.compare);
+
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
 
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.text().await?)
     }
@@ -87,11 +60,7 @@ impl HfApi {
     /// Get the raw diff between two revisions.
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/compare/{compare}?raw=true
     pub async fn get_raw_diff(&self, params: &GetRawDiffParams) -> Result<String> {
-        let url = format!(
-            "{}/compare/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.compare
-        );
+        let url = format!("{}/compare/{}", self.api_url(params.repo_type, &params.repo_id), params.compare);
 
         let response = self
             .inner
@@ -103,11 +72,7 @@ impl HfApi {
             .await?;
 
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.text().await?)
     }
@@ -115,18 +80,11 @@ impl HfApi {
     /// Create a new branch.
     /// Endpoint: POST /api/{repo_type}s/{repo_id}/branch/{branch}
     pub async fn create_branch(&self, params: &CreateBranchParams) -> Result<()> {
-        let url = format!(
-            "{}/branch/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.branch
-        );
+        let url = format!("{}/branch/{}", self.api_url(params.repo_type, &params.repo_id), params.branch);
 
         let mut body = serde_json::Map::new();
         if let Some(ref revision) = params.revision {
-            body.insert(
-                "startingPoint".into(),
-                serde_json::Value::String(revision.clone()),
-            );
+            body.insert("startingPoint".into(), serde_json::Value::String(revision.clone()));
         }
 
         let response = self
@@ -138,53 +96,28 @@ impl HfApi {
             .send()
             .await?;
 
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     /// Delete a branch.
     /// Endpoint: DELETE /api/{repo_type}s/{repo_id}/branch/{branch}
     pub async fn delete_branch(&self, params: &DeleteBranchParams) -> Result<()> {
-        let url = format!(
-            "{}/branch/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.branch
-        );
+        let url = format!("{}/branch/{}", self.api_url(params.repo_type, &params.repo_id), params.branch);
 
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
+
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
-
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
         Ok(())
     }
 
     /// Create a new tag.
     /// Endpoint: POST /api/{repo_type}s/{repo_id}/tag/{revision}
     pub async fn create_tag(&self, params: &CreateTagParams) -> Result<()> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!(
-            "{}/tag/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            revision
-        );
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = format!("{}/tag/{}", self.api_url(params.repo_type, &params.repo_id), revision);
 
         let mut body = serde_json::json!({ "tag": params.tag });
         if let Some(ref message) = params.message {
@@ -200,38 +133,20 @@ impl HfApi {
             .send()
             .await?;
 
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     /// Delete a tag.
     /// Endpoint: DELETE /api/{repo_type}s/{repo_id}/tag/{tag}
     pub async fn delete_tag(&self, params: &DeleteTagParams) -> Result<()> {
-        let url = format!(
-            "{}/tag/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.tag
-        );
+        let url = format!("{}/tag/{}", self.api_url(params.repo_type, &params.repo_id), params.tag);
 
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
+
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
-
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
         Ok(())
     }
 }

--- a/huggingface_hub/src/api/discussions.rs
+++ b/huggingface_hub/src/api/discussions.rs
@@ -1,21 +1,15 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    ChangeDiscussionStatusParams, CommentDiscussionParams, CreateDiscussionParams,
-    CreatePullRequestParams, DiscussionComment, DiscussionWithDetails, DiscussionsResponse,
-    EditDiscussionCommentParams, GetDiscussionDetailsParams, GetRepoDiscussionsParams,
-    HideDiscussionCommentParams, MergePullRequestParams, RenameDiscussionParams,
+    ChangeDiscussionStatusParams, CommentDiscussionParams, CreateDiscussionParams, CreatePullRequestParams,
+    DiscussionComment, DiscussionWithDetails, DiscussionsResponse, EditDiscussionCommentParams,
+    GetDiscussionDetailsParams, GetRepoDiscussionsParams, HideDiscussionCommentParams, MergePullRequestParams,
+    RenameDiscussionParams,
 };
 
 impl HfApi {
-    pub async fn get_repo_discussions(
-        &self,
-        params: &GetRepoDiscussionsParams,
-    ) -> Result<DiscussionsResponse> {
-        let url = format!(
-            "{}/discussions",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+    pub async fn get_repo_discussions(&self, params: &GetRepoDiscussionsParams) -> Result<DiscussionsResponse> {
+        let url = format!("{}/discussions", self.api_url(params.repo_type, &params.repo_id));
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref author) = params.author {
             query.push(("author".into(), author.clone()));
@@ -35,49 +29,22 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn get_discussion_details(
-        &self,
-        params: &GetDiscussionDetailsParams,
-    ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.discussion_num
-        );
+    pub async fn get_discussion_details(&self, params: &GetDiscussionDetailsParams) -> Result<DiscussionWithDetails> {
+        let url = format!("{}/discussions/{}", self.api_url(params.repo_type, &params.repo_id), params.discussion_num);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn create_discussion(
-        &self,
-        params: &CreateDiscussionParams,
-    ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+    pub async fn create_discussion(&self, params: &CreateDiscussionParams) -> Result<DiscussionWithDetails> {
+        let url = format!("{}/discussions", self.api_url(params.repo_type, &params.repo_id));
         let mut body = serde_json::json!({ "title": params.title });
         if let Some(ref desc) = params.description {
             body["description"] = serde_json::json!(desc);
@@ -91,23 +58,13 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn create_pull_request(
-        &self,
-        params: &CreatePullRequestParams,
-    ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+    pub async fn create_pull_request(&self, params: &CreatePullRequestParams) -> Result<DiscussionWithDetails> {
+        let url = format!("{}/discussions", self.api_url(params.repo_type, &params.repo_id));
         let mut body = serde_json::json!({
             "title": params.title,
             "pullRequest": true,
@@ -124,19 +81,12 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn comment_discussion(
-        &self,
-        params: &CommentDiscussionParams,
-    ) -> Result<DiscussionComment> {
+    pub async fn comment_discussion(&self, params: &CommentDiscussionParams) -> Result<DiscussionComment> {
         let url = format!(
             "{}/discussions/{}/comment",
             self.api_url(params.repo_type, &params.repo_id),
@@ -152,19 +102,12 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn edit_discussion_comment(
-        &self,
-        params: &EditDiscussionCommentParams,
-    ) -> Result<DiscussionComment> {
+    pub async fn edit_discussion_comment(&self, params: &EditDiscussionCommentParams) -> Result<DiscussionComment> {
         let url = format!(
             "{}/discussions/{}/comment/{}/edit",
             self.api_url(params.repo_type, &params.repo_id),
@@ -181,51 +124,28 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn hide_discussion_comment(
-        &self,
-        params: &HideDiscussionCommentParams,
-    ) -> Result<DiscussionComment> {
+    pub async fn hide_discussion_comment(&self, params: &HideDiscussionCommentParams) -> Result<DiscussionComment> {
         let url = format!(
             "{}/discussions/{}/comment/{}/hide",
             self.api_url(params.repo_type, &params.repo_id),
             params.discussion_num,
             params.comment_id
         );
+        let response = self.inner.client.put(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .put(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn rename_discussion(
-        &self,
-        params: &RenameDiscussionParams,
-    ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions/{}/title",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.discussion_num
-        );
+    pub async fn rename_discussion(&self, params: &RenameDiscussionParams) -> Result<DiscussionWithDetails> {
+        let url =
+            format!("{}/discussions/{}/title", self.api_url(params.repo_type, &params.repo_id), params.discussion_num);
         let body = serde_json::json!({ "title": params.new_title });
         let response = self
             .inner
@@ -236,11 +156,7 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
@@ -249,11 +165,8 @@ impl HfApi {
         &self,
         params: &ChangeDiscussionStatusParams,
     ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions/{}/status",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.discussion_num
-        );
+        let url =
+            format!("{}/discussions/{}/status", self.api_url(params.repo_type, &params.repo_id), params.discussion_num);
         let body = serde_json::json!({ "status": params.new_status });
         let response = self
             .inner
@@ -264,37 +177,17 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn merge_pull_request(
-        &self,
-        params: &MergePullRequestParams,
-    ) -> Result<DiscussionWithDetails> {
-        let url = format!(
-            "{}/discussions/{}/merge",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.discussion_num
-        );
+    pub async fn merge_pull_request(&self, params: &MergePullRequestParams) -> Result<DiscussionWithDetails> {
+        let url =
+            format!("{}/discussions/{}/merge", self.api_url(params.repo_type, &params.repo_id), params.discussion_num);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Generic,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }

--- a/huggingface_hub/src/api/files.rs
+++ b/huggingface_hub/src/api/files.rs
@@ -8,19 +8,16 @@ use crate::client::HfApi;
 use crate::constants;
 use crate::error::{HfError, Result};
 use crate::types::{
-    AddSource, CommitInfo, CommitOperation, CreateCommitParams, DeleteFileParams,
-    DeleteFolderParams, DownloadFileParams, GetPathsInfoParams, ListRepoFilesParams,
-    ListRepoTreeParams, RepoTreeEntry, UploadFileParams, UploadFolderParams,
+    AddSource, CommitInfo, CommitOperation, CreateCommitParams, DeleteFileParams, DeleteFolderParams,
+    DownloadFileParams, GetPathsInfoParams, ListRepoFilesParams, ListRepoTreeParams, RepoTreeEntry, UploadFileParams,
+    UploadFolderParams,
 };
 
 impl HfApi {
     /// List file paths in a repository (convenience wrapper over list_repo_tree).
     /// Returns all file paths recursively.
     pub async fn list_repo_files(&self, params: &ListRepoFilesParams) -> Result<Vec<String>> {
-        let tree_params = ListRepoTreeParams::builder()
-            .repo_id(&params.repo_id)
-            .recursive(true)
-            .build();
+        let tree_params = ListRepoTreeParams::builder().repo_id(&params.repo_id).recursive(true).build();
         let tree_params = ListRepoTreeParams {
             revision: params.revision.clone(),
             repo_type: params.repo_type,
@@ -42,19 +39,9 @@ impl HfApi {
 
     /// List files and directories in a repository tree.
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/tree/{revision}
-    pub fn list_repo_tree(
-        &self,
-        params: &ListRepoTreeParams,
-    ) -> impl Stream<Item = Result<RepoTreeEntry>> + '_ {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url_str = format!(
-            "{}/tree/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            revision
-        );
+    pub fn list_repo_tree(&self, params: &ListRepoTreeParams) -> impl Stream<Item = Result<RepoTreeEntry>> + '_ {
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url_str = format!("{}/tree/{}", self.api_url(params.repo_type, &params.repo_id), revision);
         let url = Url::parse(&url_str).unwrap();
 
         let mut query: Vec<(String, String)> = Vec::new();
@@ -71,15 +58,8 @@ impl HfApi {
     /// Get info about specific paths in a repository.
     /// Endpoint: POST /api/{repo_type}s/{repo_id}/paths-info/{revision}
     pub async fn get_paths_info(&self, params: &GetPathsInfoParams) -> Result<Vec<RepoTreeEntry>> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!(
-            "{}/paths-info/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            revision
-        );
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = format!("{}/paths-info/{}", self.api_url(params.repo_type, &params.repo_id), revision);
 
         let body = serde_json::json!({
             "paths": params.paths,
@@ -116,26 +96,12 @@ impl HfApi {
     ///
     /// Endpoint: GET {endpoint}/{prefix}{repo_id}/resolve/{revision}/{filename}
     pub async fn download_file(&self, params: &DownloadFileParams) -> Result<PathBuf> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url = self.download_url(
-            params.repo_type,
-            &params.repo_id,
-            revision,
-            &params.filename,
-        );
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = self.download_url(params.repo_type, &params.repo_id, revision, &params.filename);
 
         #[cfg(feature = "xet")]
         {
-            let head_response = self
-                .inner
-                .client
-                .head(&url)
-                .headers(self.auth_headers())
-                .send()
-                .await?;
+            let head_response = self.inner.client.head(&url).headers(self.auth_headers()).send().await?;
 
             let head_response = self
                 .check_response(
@@ -147,23 +113,14 @@ impl HfApi {
                 )
                 .await?;
 
-            let has_xet_hash = head_response
-                .headers()
-                .get(constants::HEADER_X_XET_HASH)
-                .is_some();
+            let has_xet_hash = head_response.headers().get(constants::HEADER_X_XET_HASH).is_some();
 
             if has_xet_hash {
                 return crate::xet::xet_download(self, params, &head_response).await;
             }
         }
 
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(
                 response,
@@ -208,22 +165,14 @@ impl HfApi {
     ///
     /// Endpoint: POST /api/{repo_type}s/{repo_id}/commit/{revision}
     pub async fn create_commit(&self, params: &CreateCommitParams) -> Result<CommitInfo> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!(
-            "{}/commit/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            revision
-        );
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = format!("{}/commit/{}", self.api_url(params.repo_type, &params.repo_id), revision);
 
         // Determine which files should be uploaded via xet (LFS) vs inline
         // (regular). Files uploaded via xet are referenced by their SHA256 OID
         // in the commit NDJSON.
-        let lfs_uploaded: HashMap<String, (String, u64)> = self
-            .preupload_and_upload_lfs_files(params, revision)
-            .await?;
+        let lfs_uploaded: HashMap<String, (String, u64)> =
+            self.preupload_and_upload_lfs_files(params, revision).await?;
 
         let mut ndjson_lines: Vec<Vec<u8>> = Vec::new();
 
@@ -239,10 +188,7 @@ impl HfApi {
 
         for op in &params.operations {
             let line = match op {
-                CommitOperation::Add {
-                    path_in_repo,
-                    source,
-                } => {
+                CommitOperation::Add { path_in_repo, source } => {
                     if let Some((oid, size)) = lfs_uploaded.get(path_in_repo) {
                         serde_json::json!({
                             "key": "lfsFile",
@@ -256,13 +202,13 @@ impl HfApi {
                     } else {
                         Self::inline_base64_entry(path_in_repo, source).await?
                     }
-                }
+                },
                 CommitOperation::Delete { path_in_repo } => {
                     serde_json::json!({
                         "key": "deletedFile",
                         "value": {"path": path_in_repo}
                     })
-                }
+                },
             };
             ndjson_lines.push(serde_json::to_vec(&line)?);
         }
@@ -276,10 +222,7 @@ impl HfApi {
             .collect();
 
         let mut headers = self.auth_headers();
-        headers.insert(
-            reqwest::header::CONTENT_TYPE,
-            "application/x-ndjson".parse().unwrap(),
-        );
+        headers.insert(reqwest::header::CONTENT_TYPE, "application/x-ndjson".parse().unwrap());
 
         let mut request = self.inner.client.post(&url).headers(headers).body(body);
 
@@ -289,19 +232,12 @@ impl HfApi {
 
         let response = request.send().await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    async fn inline_base64_entry(
-        path_in_repo: &str,
-        source: &AddSource,
-    ) -> Result<serde_json::Value> {
+    async fn inline_base64_entry(path_in_repo: &str, source: &AddSource) -> Result<serde_json::Value> {
         use base64::Engine;
         let content = match source {
             AddSource::File(path) => tokio::fs::read(path).await?,
@@ -364,14 +300,8 @@ impl HfApi {
         .await?;
 
         if let Some(ref delete_patterns) = params.delete_patterns {
-            let revision = params
-                .revision
-                .as_deref()
-                .unwrap_or(constants::DEFAULT_REVISION);
-            let tree_params = ListRepoTreeParams::builder()
-                .repo_id(&params.repo_id)
-                .recursive(true)
-                .build();
+            let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+            let tree_params = ListRepoTreeParams::builder().repo_id(&params.repo_id).recursive(true).build();
             let tree_params = ListRepoTreeParams {
                 revision: Some(revision.to_string()),
                 repo_type: params.repo_type,
@@ -389,10 +319,7 @@ impl HfApi {
             }
         }
 
-        let commit_message = params
-            .commit_message
-            .clone()
-            .unwrap_or_else(|| "Upload folder".to_string());
+        let commit_message = params.commit_message.clone().unwrap_or_else(|| "Upload folder".to_string());
 
         let commit_params = CreateCommitParams::builder()
             .repo_id(&params.repo_id)
@@ -438,15 +365,9 @@ impl HfApi {
 
     /// Delete a folder from a repository. Lists files under the path and deletes them.
     pub async fn delete_folder(&self, params: &DeleteFolderParams) -> Result<CommitInfo> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
 
-        let tree_params = ListRepoTreeParams::builder()
-            .repo_id(&params.repo_id)
-            .recursive(true)
-            .build();
+        let tree_params = ListRepoTreeParams::builder().repo_id(&params.repo_id).recursive(true).build();
         let tree_params = ListRepoTreeParams {
             revision: Some(revision.to_string()),
             repo_type: params.repo_type,
@@ -532,10 +453,7 @@ impl HfApi {
             .operations
             .iter()
             .filter_map(|op| match op {
-                CommitOperation::Add {
-                    path_in_repo,
-                    source,
-                } => Some((path_in_repo, source)),
+                CommitOperation::Add { path_in_repo, source } => Some((path_in_repo, source)),
                 _ => None,
             })
             .collect();
@@ -568,11 +486,7 @@ impl HfApi {
         let lfs_files: Vec<&(String, u64, Vec<u8>, &AddSource)> = file_infos
             .iter()
             .filter(|(path, size, _, _)| {
-                *size > 0
-                    && upload_modes
-                        .get(path.as_str())
-                        .map(|m| m == "lfs")
-                        .unwrap_or(false)
+                *size > 0 && upload_modes.get(path.as_str()).map(|m| m == "lfs").unwrap_or(false)
             })
             .collect();
 
@@ -588,8 +502,7 @@ impl HfApi {
         }
 
         #[cfg(feature = "xet")]
-        self.upload_lfs_files_via_xet(params, revision, &lfs_files)
-            .await
+        self.upload_lfs_files_via_xet(params, revision, &lfs_files).await
     }
 
     /// Call the Hub preupload endpoint to determine upload mode per file.
@@ -603,11 +516,7 @@ impl HfApi {
     ) -> Result<HashMap<String, String>> {
         use base64::Engine;
 
-        let url = format!(
-            "{}/preupload/{}",
-            self.api_url(repo_type, repo_id),
-            revision
-        );
+        let url = format!("{}/preupload/{}", self.api_url(repo_type, repo_id), revision);
 
         let files_payload: Vec<serde_json::Value> = files
             .iter()
@@ -637,11 +546,7 @@ impl HfApi {
 
         let preupload: PreuploadResponse = response.json().await?;
 
-        Ok(preupload
-            .files
-            .into_iter()
-            .map(|f| (f.path, f.upload_mode))
-            .collect())
+        Ok(preupload.files.into_iter().map(|f| (f.path, f.upload_mode)).collect())
     }
 }
 
@@ -662,10 +567,7 @@ impl HfApi {
         }
 
         // Step 5: Call LFS batch endpoint to negotiate transfer method
-        let objects: Vec<(&str, u64)> = lfs_with_sha
-            .iter()
-            .map(|(_, size, oid, _)| (oid.as_str(), *size))
-            .collect();
+        let objects: Vec<(&str, u64)> = lfs_with_sha.iter().map(|(_, size, oid, _)| (oid.as_str(), *size)).collect();
 
         let chosen_transfer = self
             .post_lfs_batch_info(&params.repo_id, params.repo_type, revision, &objects)
@@ -681,14 +583,7 @@ impl HfApi {
             .map(|(path, _, _, source)| (path.clone(), (*source).clone()))
             .collect();
 
-        crate::xet::xet_upload(
-            self,
-            &xet_files,
-            &params.repo_id,
-            params.repo_type,
-            revision,
-        )
-        .await?;
+        crate::xet::xet_upload(self, &xet_files, &params.repo_id, params.repo_type, revision).await?;
 
         let result: HashMap<String, (String, u64)> = lfs_with_sha
             .into_iter()
@@ -708,10 +603,7 @@ impl HfApi {
         objects: &[(&str, u64)],
     ) -> Result<Option<String>> {
         let prefix = constants::repo_type_url_prefix(repo_type);
-        let url = format!(
-            "{}/{}{}.git/info/lfs/objects/batch",
-            self.inner.endpoint, prefix, repo_id
-        );
+        let url = format!("{}/{}{}.git/info/lfs/objects/batch", self.inner.endpoint, prefix, repo_id);
 
         let objects_payload: Vec<serde_json::Value> = objects
             .iter()
@@ -732,23 +624,10 @@ impl HfApi {
         });
 
         let mut headers = self.auth_headers();
-        headers.insert(
-            reqwest::header::ACCEPT,
-            "application/vnd.git-lfs+json".parse().unwrap(),
-        );
-        headers.insert(
-            reqwest::header::CONTENT_TYPE,
-            "application/vnd.git-lfs+json".parse().unwrap(),
-        );
+        headers.insert(reqwest::header::ACCEPT, "application/vnd.git-lfs+json".parse().unwrap());
+        headers.insert(reqwest::header::CONTENT_TYPE, "application/vnd.git-lfs+json".parse().unwrap());
 
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(headers)
-            .json(&body)
-            .send()
-            .await?;
+        let response = self.inner.client.post(&url).headers(headers).json(&body).send().await?;
 
         let response = self
             .check_response(response, Some(repo_id), crate::error::NotFoundContext::Repo)
@@ -766,7 +645,7 @@ async fn sha256_of_source(source: &AddSource) -> Result<String> {
         AddSource::Bytes(bytes) => {
             let hash = Sha256::digest(bytes);
             Ok(format!("{:x}", hash))
-        }
+        },
         AddSource::File(path) => {
             use tokio::io::AsyncReadExt;
             let mut file = tokio::fs::File::open(path).await?;
@@ -780,7 +659,7 @@ async fn sha256_of_source(source: &AddSource) -> Result<String> {
                 hasher.update(&buf[..n]);
             }
             Ok(format!("{:x}", hasher.finalize()))
-        }
+        },
     }
 }
 
@@ -790,7 +669,7 @@ async fn read_size_and_sample(source: &AddSource) -> Result<(u64, Vec<u8>)> {
             let size = bytes.len() as u64;
             let sample = bytes[..std::cmp::min(bytes.len(), 512)].to_vec();
             Ok((size, sample))
-        }
+        },
         AddSource::File(path) => {
             use tokio::io::AsyncReadExt;
             let mut file = tokio::fs::File::open(path).await?;
@@ -800,7 +679,7 @@ async fn read_size_and_sample(source: &AddSource) -> Result<(u64, Vec<u8>)> {
             let n = file.read(&mut sample).await?;
             sample.truncate(n);
             Ok((size, sample))
-        }
+        },
     }
 }
 
@@ -821,19 +700,10 @@ async fn collect_files_recursive(
         let metadata = entry.metadata().await?;
 
         if metadata.is_dir() {
-            Box::pin(collect_files_recursive(
-                root,
-                &path,
-                base_repo_path,
-                allow_patterns,
-                ignore_patterns,
-                operations,
-            ))
-            .await?;
+            Box::pin(collect_files_recursive(root, &path, base_repo_path, allow_patterns, ignore_patterns, operations))
+                .await?;
         } else if metadata.is_file() {
-            let relative = path
-                .strip_prefix(root)
-                .map_err(|e| HfError::Other(e.to_string()))?;
+            let relative = path.strip_prefix(root).map_err(|e| HfError::Other(e.to_string()))?;
             let relative_str = relative.to_string_lossy();
 
             if let Some(ref allow) = allow_patterns {
@@ -866,12 +736,9 @@ async fn collect_files_recursive(
 /// Check if a path matches any of the given glob patterns using the `globset` crate.
 fn matches_any_glob(patterns: &[String], path: &str) -> bool {
     use globset::Glob;
-    patterns.iter().any(|p| {
-        Glob::new(p)
-            .ok()
-            .map(|g| g.compile_matcher().is_match(path))
-            .unwrap_or(false)
-    })
+    patterns
+        .iter()
+        .any(|p| Glob::new(p).ok().map(|g| g.compile_matcher().is_match(path)).unwrap_or(false))
 }
 
 sync_api! {

--- a/huggingface_hub/src/api/inference_endpoints.rs
+++ b/huggingface_hub/src/api/inference_endpoints.rs
@@ -1,10 +1,9 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    CreateInferenceEndpointParams, DeleteInferenceEndpointParams, GetInferenceEndpointParams,
-    InferenceEndpointInfo, ListInferenceEndpointsParams, PauseInferenceEndpointParams,
-    ResumeInferenceEndpointParams, ScaleToZeroInferenceEndpointParams,
-    UpdateInferenceEndpointParams,
+    CreateInferenceEndpointParams, DeleteInferenceEndpointParams, GetInferenceEndpointParams, InferenceEndpointInfo,
+    ListInferenceEndpointsParams, PauseInferenceEndpointParams, ResumeInferenceEndpointParams,
+    ScaleToZeroInferenceEndpointParams, UpdateInferenceEndpointParams,
 };
 
 const IE_API_BASE: &str = "https://api.endpoints.huggingface.cloud/v2/endpoint";
@@ -16,7 +15,7 @@ impl HfApi {
             None => {
                 let user = self.whoami().await?;
                 Ok(user.username)
-            }
+            },
         }
     }
 
@@ -75,19 +74,10 @@ impl HfApi {
         Ok(response.json().await?)
     }
 
-    pub async fn get_inference_endpoint(
-        &self,
-        params: &GetInferenceEndpointParams,
-    ) -> Result<InferenceEndpointInfo> {
+    pub async fn get_inference_endpoint(&self, params: &GetInferenceEndpointParams) -> Result<InferenceEndpointInfo> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}/{}", params.name);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -100,24 +90,13 @@ impl HfApi {
     ) -> Result<Vec<InferenceEndpointInfo>> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}");
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         let wrapper: serde_json::Value = response.json().await?;
-        let items = wrapper
-            .get("items")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
-        let endpoints: Vec<InferenceEndpointInfo> =
-            serde_json::from_value(serde_json::json!(items))?;
+        let items = wrapper.get("items").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+        let endpoints: Vec<InferenceEndpointInfo> = serde_json::from_value(serde_json::json!(items))?;
         Ok(endpoints)
     }
 
@@ -139,10 +118,7 @@ impl HfApi {
         if let Some(ref itype) = params.instance_type {
             compute.insert("instanceType".into(), serde_json::json!(itype));
         }
-        if params.min_replica.is_some()
-            || params.max_replica.is_some()
-            || params.scale_to_zero_timeout.is_some()
-        {
+        if params.min_replica.is_some() || params.max_replica.is_some() || params.scale_to_zero_timeout.is_some() {
             let mut scaling = serde_json::Map::new();
             if let Some(min) = params.min_replica {
                 scaling.insert("minReplica".into(), serde_json::json!(min));
@@ -193,19 +169,10 @@ impl HfApi {
         Ok(response.json().await?)
     }
 
-    pub async fn delete_inference_endpoint(
-        &self,
-        params: &DeleteInferenceEndpointParams,
-    ) -> Result<()> {
+    pub async fn delete_inference_endpoint(&self, params: &DeleteInferenceEndpointParams) -> Result<()> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}/{}", params.name);
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(())
@@ -217,13 +184,7 @@ impl HfApi {
     ) -> Result<InferenceEndpointInfo> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}/{}/pause", params.name);
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -236,13 +197,7 @@ impl HfApi {
     ) -> Result<InferenceEndpointInfo> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}/{}/resume", params.name);
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -255,13 +210,7 @@ impl HfApi {
     ) -> Result<InferenceEndpointInfo> {
         let ns = self.resolve_ie_namespace(&params.namespace).await?;
         let url = format!("{IE_API_BASE}/{ns}/{}/scale-to-zero", params.name);
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;

--- a/huggingface_hub/src/api/jobs.rs
+++ b/huggingface_hub/src/api/jobs.rs
@@ -1,8 +1,8 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    CreateScheduledJobParams, JobHardware, JobInfo, JobLogEntry, JobMetrics, ListJobsParams,
-    RunJobParams, ScheduledJobInfo,
+    CreateScheduledJobParams, JobHardware, JobInfo, JobLogEntry, JobMetrics, ListJobsParams, RunJobParams,
+    ScheduledJobInfo,
 };
 
 impl HfApi {
@@ -12,7 +12,7 @@ impl HfApi {
             None => {
                 let user = self.whoami().await?;
                 Ok(user.username)
-            }
+            },
         }
     }
 
@@ -71,17 +71,9 @@ impl HfApi {
     }
 
     pub async fn inspect_job(&self, job_id: &str, namespace: Option<&str>) -> Result<JobInfo> {
-        let ns = self
-            .resolve_jobs_namespace(&namespace.map(String::from))
-            .await?;
+        let ns = self.resolve_jobs_namespace(&namespace.map(String::from)).await?;
         let url = format!("{}/api/jobs/{}/{}", self.inner.endpoint, ns, job_id);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -89,61 +81,29 @@ impl HfApi {
     }
 
     pub async fn cancel_job(&self, job_id: &str, namespace: Option<&str>) -> Result<JobInfo> {
-        let ns = self
-            .resolve_jobs_namespace(&namespace.map(String::from))
-            .await?;
+        let ns = self.resolve_jobs_namespace(&namespace.map(String::from)).await?;
         let url = format!("{}/api/jobs/{}/{}/cancel", self.inner.endpoint, ns, job_id);
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn fetch_job_logs(
-        &self,
-        job_id: &str,
-        namespace: Option<&str>,
-    ) -> Result<Vec<JobLogEntry>> {
-        let ns = self
-            .resolve_jobs_namespace(&namespace.map(String::from))
-            .await?;
+    pub async fn fetch_job_logs(&self, job_id: &str, namespace: Option<&str>) -> Result<Vec<JobLogEntry>> {
+        let ns = self.resolve_jobs_namespace(&namespace.map(String::from)).await?;
         let url = format!("{}/api/jobs/{}/{}/logs", self.inner.endpoint, ns, job_id);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn fetch_job_metrics(
-        &self,
-        job_id: &str,
-        namespace: Option<&str>,
-    ) -> Result<Vec<JobMetrics>> {
-        let ns = self
-            .resolve_jobs_namespace(&namespace.map(String::from))
-            .await?;
+    pub async fn fetch_job_metrics(&self, job_id: &str, namespace: Option<&str>) -> Result<Vec<JobMetrics>> {
+        let ns = self.resolve_jobs_namespace(&namespace.map(String::from)).await?;
         let url = format!("{}/api/jobs/{}/{}/metrics", self.inner.endpoint, ns, job_id);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -152,23 +112,14 @@ impl HfApi {
 
     pub async fn list_job_hardware(&self) -> Result<Vec<JobHardware>> {
         let url = format!("{}/api/jobs/hardware", self.inner.endpoint);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn create_scheduled_job(
-        &self,
-        params: &CreateScheduledJobParams,
-    ) -> Result<ScheduledJobInfo> {
+    pub async fn create_scheduled_job(&self, params: &CreateScheduledJobParams) -> Result<ScheduledJobInfo> {
         let url = format!("{}/api/jobs/scheduled", self.inner.endpoint);
         let mut body = serde_json::json!({
             "dockerImage": params.image,
@@ -212,13 +163,7 @@ impl HfApi {
 
     pub async fn list_scheduled_jobs(&self) -> Result<Vec<ScheduledJobInfo>> {
         let url = format!("{}/api/jobs/scheduled", self.inner.endpoint);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -226,17 +171,8 @@ impl HfApi {
     }
 
     pub async fn inspect_scheduled_job(&self, scheduled_job_id: &str) -> Result<ScheduledJobInfo> {
-        let url = format!(
-            "{}/api/jobs/scheduled/{}",
-            self.inner.endpoint, scheduled_job_id
-        );
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/jobs/scheduled/{}", self.inner.endpoint, scheduled_job_id);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -244,34 +180,16 @@ impl HfApi {
     }
 
     pub async fn delete_scheduled_job(&self, scheduled_job_id: &str) -> Result<()> {
-        let url = format!(
-            "{}/api/jobs/scheduled/{}",
-            self.inner.endpoint, scheduled_job_id
-        );
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/jobs/scheduled/{}", self.inner.endpoint, scheduled_job_id);
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(())
     }
 
     pub async fn suspend_scheduled_job(&self, scheduled_job_id: &str) -> Result<ScheduledJobInfo> {
-        let url = format!(
-            "{}/api/jobs/scheduled/{}/suspend",
-            self.inner.endpoint, scheduled_job_id
-        );
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/jobs/scheduled/{}/suspend", self.inner.endpoint, scheduled_job_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -279,17 +197,8 @@ impl HfApi {
     }
 
     pub async fn resume_scheduled_job(&self, scheduled_job_id: &str) -> Result<ScheduledJobInfo> {
-        let url = format!(
-            "{}/api/jobs/scheduled/{}/resume",
-            self.inner.endpoint, scheduled_job_id
-        );
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/jobs/scheduled/{}/resume", self.inner.endpoint, scheduled_job_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;

--- a/huggingface_hub/src/api/likes.rs
+++ b/huggingface_hub/src/api/likes.rs
@@ -1,74 +1,40 @@
+use futures::Stream;
+use url::Url;
+
 use crate::client::HfApi;
 use crate::constants;
 use crate::error::Result;
 use crate::types::{LikeParams, LikedRepo, ListLikedReposParams, ListRepoLikersParams, User};
-use futures::Stream;
-use url::Url;
 
 impl HfApi {
     pub async fn like(&self, params: &LikeParams) -> Result<()> {
         let url = format!("{}/like", self.api_url(params.repo_type, &params.repo_id));
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
         Ok(())
     }
 
     pub async fn unlike(&self, params: &LikeParams) -> Result<()> {
         let url = format!("{}/like", self.api_url(params.repo_type, &params.repo_id));
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
         Ok(())
     }
 
     pub async fn list_liked_repos(&self, params: &ListLikedReposParams) -> Result<Vec<LikedRepo>> {
-        let url = format!(
-            "{}/api/users/{}/likes",
-            self.inner.endpoint, params.username
-        );
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/users/{}/likes", self.inner.endpoint, params.username);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub fn list_repo_likers(
-        &self,
-        params: &ListRepoLikersParams,
-    ) -> impl Stream<Item = Result<User>> + '_ {
+    pub fn list_repo_likers(&self, params: &ListRepoLikersParams) -> impl Stream<Item = Result<User>> + '_ {
         let segment = constants::repo_type_api_segment(params.repo_type);
-        let url_str = format!(
-            "{}/api/{}/{}/likers",
-            self.inner.endpoint, segment, params.repo_id
-        );
+        let url_str = format!("{}/api/{}/{}/likers", self.inner.endpoint, segment, params.repo_id);
         let url = Url::parse(&url_str).unwrap();
         self.paginate(url, vec![])
     }

--- a/huggingface_hub/src/api/papers.rs
+++ b/huggingface_hub/src/api/papers.rs
@@ -1,8 +1,7 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    DailyPaper, ListDailyPapersParams, ListPapersParams, PaperInfo, PaperInfoParams,
-    PaperSearchResult,
+    DailyPaper, ListDailyPapersParams, ListPapersParams, PaperInfo, PaperInfoParams, PaperSearchResult,
 };
 
 impl HfApi {
@@ -29,10 +28,7 @@ impl HfApi {
         Ok(response.json().await?)
     }
 
-    pub async fn list_daily_papers(
-        &self,
-        params: &ListDailyPapersParams,
-    ) -> Result<Vec<DailyPaper>> {
+    pub async fn list_daily_papers(&self, params: &ListDailyPapersParams) -> Result<Vec<DailyPaper>> {
         let url = format!("{}/api/daily_papers", self.inner.endpoint);
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref date) = params.date {
@@ -72,13 +68,7 @@ impl HfApi {
 
     pub async fn paper_info(&self, params: &PaperInfoParams) -> Result<PaperInfo> {
         let url = format!("{}/api/papers/{}", self.inner.endpoint, params.paper_id);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;

--- a/huggingface_hub/src/api/repo.rs
+++ b/huggingface_hub/src/api/repo.rs
@@ -1,14 +1,14 @@
+use futures::Stream;
+use url::Url;
+
 use crate::client::HfApi;
 use crate::constants;
 use crate::error::{HfError, Result};
 use crate::types::{
-    CreateRepoParams, DatasetInfo, DatasetInfoParams, DeleteRepoParams, FileExistsParams,
-    ListDatasetsParams, ListModelsParams, ListSpacesParams, ModelInfo, ModelInfoParams,
-    MoveRepoParams, RepoExistsParams, RepoType, RepoUrl, RevisionExistsParams, SpaceInfo,
-    SpaceInfoParams, UpdateRepoParams,
+    CreateRepoParams, DatasetInfo, DatasetInfoParams, DeleteRepoParams, FileExistsParams, ListDatasetsParams,
+    ListModelsParams, ListSpacesParams, ModelInfo, ModelInfoParams, MoveRepoParams, RepoExistsParams, RepoType,
+    RepoUrl, RevisionExistsParams, SpaceInfo, SpaceInfoParams, UpdateRepoParams,
 };
-use futures::Stream;
-use url::Url;
 
 impl HfApi {
     /// Get info about a model repository.
@@ -18,19 +18,9 @@ impl HfApi {
         if let Some(ref revision) = params.revision {
             url = format!("{url}/revision/{revision}");
         }
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
@@ -42,19 +32,9 @@ impl HfApi {
         if let Some(ref revision) = params.revision {
             url = format!("{url}/revision/{revision}");
         }
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
@@ -66,19 +46,9 @@ impl HfApi {
         if let Some(ref revision) = params.revision {
             url = format!("{url}/revision/{revision}");
         }
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
@@ -86,13 +56,7 @@ impl HfApi {
     /// Check if a repository exists.
     pub async fn repo_exists(&self, params: &RepoExistsParams) -> Result<bool> {
         let url = self.api_url(params.repo_type, &params.repo_id);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         match response.status().as_u16() {
             200..=299 => Ok(true),
             404 => Ok(false),
@@ -105,24 +69,14 @@ impl HfApi {
                     url,
                     body,
                 })
-            }
+            },
         }
     }
 
     /// Check if a specific revision exists in a repository.
     pub async fn revision_exists(&self, params: &RevisionExistsParams) -> Result<bool> {
-        let url = format!(
-            "{}/revision/{}",
-            self.api_url(params.repo_type, &params.repo_id),
-            params.revision
-        );
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/revision/{}", self.api_url(params.repo_type, &params.repo_id), params.revision);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         match response.status().as_u16() {
             200..=299 => Ok(true),
             404 => Ok(false),
@@ -135,30 +89,16 @@ impl HfApi {
                     url: url_str,
                     body,
                 })
-            }
+            },
         }
     }
 
     /// Check if a file exists in a repository by sending a HEAD request
     /// to the download URL.
     pub async fn file_exists(&self, params: &FileExistsParams) -> Result<bool> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        let url = self.download_url(
-            params.repo_type,
-            &params.repo_id,
-            revision,
-            &params.filename,
-        );
-        let response = self
-            .inner
-            .client
-            .head(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = self.download_url(params.repo_type, &params.repo_id, revision, &params.filename);
+        let response = self.inner.client.head(&url).headers(self.auth_headers()).send().await?;
         match response.status().as_u16() {
             200..=299 => Ok(true),
             404 => Ok(false),
@@ -171,7 +111,7 @@ impl HfApi {
                     url: url_str,
                     body,
                 })
-            }
+            },
         }
     }
 }
@@ -179,10 +119,7 @@ impl HfApi {
 impl HfApi {
     /// List models on the Hub.
     /// Endpoint: GET /api/models
-    pub fn list_models(
-        &self,
-        params: &ListModelsParams,
-    ) -> impl Stream<Item = Result<ModelInfo>> + '_ {
+    pub fn list_models(&self, params: &ListModelsParams) -> impl Stream<Item = Result<ModelInfo>> + '_ {
         let url = Url::parse(&format!("{}/api/models", self.inner.endpoint)).unwrap();
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref search) = params.search {
@@ -217,10 +154,7 @@ impl HfApi {
 
     /// List datasets on the Hub.
     /// Endpoint: GET /api/datasets
-    pub fn list_datasets(
-        &self,
-        params: &ListDatasetsParams,
-    ) -> impl Stream<Item = Result<DatasetInfo>> + '_ {
+    pub fn list_datasets(&self, params: &ListDatasetsParams) -> impl Stream<Item = Result<DatasetInfo>> + '_ {
         let url = Url::parse(&format!("{}/api/datasets", self.inner.endpoint)).unwrap();
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref search) = params.search {
@@ -246,10 +180,7 @@ impl HfApi {
 
     /// List spaces on the Hub.
     /// Endpoint: GET /api/spaces
-    pub fn list_spaces(
-        &self,
-        params: &ListSpacesParams,
-    ) -> impl Stream<Item = Result<SpaceInfo>> + '_ {
+    pub fn list_spaces(&self, params: &ListSpacesParams) -> impl Stream<Item = Result<SpaceInfo>> + '_ {
         let url = Url::parse(&format!("{}/api/spaces", self.inner.endpoint)).unwrap();
         let mut query: Vec<(String, String)> = Vec::new();
         if let Some(ref search) = params.search {
@@ -346,22 +277,15 @@ impl HfApi {
             return Ok(());
         }
 
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     /// Update repository settings.
     /// Endpoint: PUT /api/{repo_type}s/{repo_id}/settings
     pub async fn update_repo_settings(&self, params: &UpdateRepoParams) -> Result<()> {
-        let url = format!(
-            "{}/settings",
-            self.api_url(params.repo_type, &params.repo_id)
-        );
+        let url = format!("{}/settings", self.api_url(params.repo_type, &params.repo_id));
         let mut body = serde_json::Map::new();
 
         if let Some(private) = params.private {
@@ -371,10 +295,7 @@ impl HfApi {
             body.insert("gated".into(), serde_json::Value::String(gated.clone()));
         }
         if let Some(ref description) = params.description {
-            body.insert(
-                "description".into(),
-                serde_json::Value::String(description.clone()),
-            );
+            body.insert("description".into(), serde_json::Value::String(description.clone()));
         }
 
         let response = self
@@ -386,12 +307,8 @@ impl HfApi {
             .send()
             .await?;
 
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 

--- a/huggingface_hub/src/api/spaces.rs
+++ b/huggingface_hub/src/api/spaces.rs
@@ -1,42 +1,23 @@
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{
-    AddSpaceSecretParams, AddSpaceVariableParams, DeleteSpaceSecretParams,
-    DeleteSpaceVariableParams, DuplicateSpaceParams, GetSpaceRuntimeParams, PauseSpaceParams,
-    RepoUrl, RequestSpaceHardwareParams, RestartSpaceParams, SetSpaceSleepTimeParams, SpaceRuntime,
+    AddSpaceSecretParams, AddSpaceVariableParams, DeleteSpaceSecretParams, DeleteSpaceVariableParams,
+    DuplicateSpaceParams, GetSpaceRuntimeParams, PauseSpaceParams, RepoUrl, RequestSpaceHardwareParams,
+    RestartSpaceParams, SetSpaceSleepTimeParams, SpaceRuntime,
 };
 
 impl HfApi {
     pub async fn get_space_runtime(&self, params: &GetSpaceRuntimeParams) -> Result<SpaceRuntime> {
-        let url = format!(
-            "{}/api/spaces/{}/runtime",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/runtime", self.inner.endpoint, params.repo_id);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
-    pub async fn request_space_hardware(
-        &self,
-        params: &RequestSpaceHardwareParams,
-    ) -> Result<SpaceRuntime> {
-        let url = format!(
-            "{}/api/spaces/{}/hardware",
-            self.inner.endpoint, params.repo_id
-        );
+    pub async fn request_space_hardware(&self, params: &RequestSpaceHardwareParams) -> Result<SpaceRuntime> {
+        let url = format!("{}/api/spaces/{}/hardware", self.inner.endpoint, params.repo_id);
         let mut body = serde_json::json!({ "flavor": params.hardware });
         if let Some(sleep_time) = params.sleep_time {
             body["sleepTime"] = serde_json::json!(sleep_time);
@@ -50,20 +31,13 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
     pub async fn set_space_sleep_time(&self, params: &SetSpaceSleepTimeParams) -> Result<()> {
-        let url = format!(
-            "{}/api/spaces/{}/sleeptime",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/sleeptime", self.inner.endpoint, params.repo_id);
         let body = serde_json::json!({ "seconds": params.sleep_time });
         let response = self
             .inner
@@ -73,64 +47,31 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     pub async fn pause_space(&self, params: &PauseSpaceParams) -> Result<SpaceRuntime> {
-        let url = format!(
-            "{}/api/spaces/{}/pause",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/pause", self.inner.endpoint, params.repo_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
     pub async fn restart_space(&self, params: &RestartSpaceParams) -> Result<SpaceRuntime> {
-        let url = format!(
-            "{}/api/spaces/{}/restart",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/restart", self.inner.endpoint, params.repo_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
-        let response = self
-            .check_response(
-                response,
-                Some(&params.repo_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }
 
     pub async fn add_space_secret(&self, params: &AddSpaceSecretParams) -> Result<()> {
-        let url = format!(
-            "{}/api/spaces/{}/secrets",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/secrets", self.inner.endpoint, params.repo_id);
         let mut body = serde_json::json!({
             "key": params.key,
             "value": params.value,
@@ -146,20 +87,13 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     pub async fn delete_space_secret(&self, params: &DeleteSpaceSecretParams) -> Result<()> {
-        let url = format!(
-            "{}/api/spaces/{}/secrets",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/secrets", self.inner.endpoint, params.repo_id);
         let body = serde_json::json!({ "key": params.key });
         let response = self
             .inner
@@ -169,20 +103,13 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     pub async fn add_space_variable(&self, params: &AddSpaceVariableParams) -> Result<()> {
-        let url = format!(
-            "{}/api/spaces/{}/variables",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/variables", self.inner.endpoint, params.repo_id);
         let mut body = serde_json::json!({
             "key": params.key,
             "value": params.value,
@@ -198,20 +125,13 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     pub async fn delete_space_variable(&self, params: &DeleteSpaceVariableParams) -> Result<()> {
-        let url = format!(
-            "{}/api/spaces/{}/variables",
-            self.inner.endpoint, params.repo_id
-        );
+        let url = format!("{}/api/spaces/{}/variables", self.inner.endpoint, params.repo_id);
         let body = serde_json::json!({ "key": params.key });
         let response = self
             .inner
@@ -221,20 +141,13 @@ impl HfApi {
             .json(&body)
             .send()
             .await?;
-        self.check_response(
-            response,
-            Some(&params.repo_id),
-            crate::error::NotFoundContext::Repo,
-        )
-        .await?;
+        self.check_response(response, Some(&params.repo_id), crate::error::NotFoundContext::Repo)
+            .await?;
         Ok(())
     }
 
     pub async fn duplicate_space(&self, params: &DuplicateSpaceParams) -> Result<RepoUrl> {
-        let url = format!(
-            "{}/api/spaces/{}/duplicate",
-            self.inner.endpoint, params.from_id
-        );
+        let url = format!("{}/api/spaces/{}/duplicate", self.inner.endpoint, params.from_id);
         let mut body = serde_json::Map::new();
         if let Some(ref to_id) = params.to_id {
             body.insert("repository".into(), serde_json::json!(to_id));
@@ -266,11 +179,7 @@ impl HfApi {
             .send()
             .await?;
         let response = self
-            .check_response(
-                response,
-                Some(&params.from_id),
-                crate::error::NotFoundContext::Repo,
-            )
+            .check_response(response, Some(&params.from_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(response.json().await?)
     }

--- a/huggingface_hub/src/api/users.rs
+++ b/huggingface_hub/src/api/users.rs
@@ -1,21 +1,16 @@
+use futures::Stream;
+use url::Url;
+
 use crate::client::HfApi;
 use crate::error::Result;
 use crate::types::{Organization, User};
-use futures::Stream;
-use url::Url;
 
 impl HfApi {
     /// Get authenticated user info.
     /// Endpoint: GET /api/whoami-v2
     pub async fn whoami(&self) -> Result<User> {
         let url = format!("{}/api/whoami-v2", self.inner.endpoint);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -34,13 +29,7 @@ impl HfApi {
     /// Endpoint: GET /api/users/{username}/overview
     pub async fn get_user_overview(&self, username: &str) -> Result<User> {
         let url = format!("{}/api/users/{}/overview", self.inner.endpoint, username);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -50,17 +39,8 @@ impl HfApi {
     /// Get overview of an organization.
     /// Endpoint: GET /api/organizations/{organization}/overview
     pub async fn get_organization_overview(&self, organization: &str) -> Result<Organization> {
-        let url = format!(
-            "{}/api/organizations/{}/overview",
-            self.inner.endpoint, organization
-        );
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/organizations/{}/overview", self.inner.endpoint, organization);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -70,36 +50,21 @@ impl HfApi {
     /// List followers of a user.
     /// Endpoint: GET /api/users/{username}/followers
     pub fn list_user_followers(&self, username: &str) -> impl Stream<Item = Result<User>> + '_ {
-        let url = Url::parse(&format!(
-            "{}/api/users/{}/followers",
-            self.inner.endpoint, username
-        ))
-        .unwrap();
+        let url = Url::parse(&format!("{}/api/users/{}/followers", self.inner.endpoint, username)).unwrap();
         self.paginate(url, vec![])
     }
 
     /// List users that a user is following.
     /// Endpoint: GET /api/users/{username}/following
     pub fn list_user_following(&self, username: &str) -> impl Stream<Item = Result<User>> + '_ {
-        let url = Url::parse(&format!(
-            "{}/api/users/{}/following",
-            self.inner.endpoint, username
-        ))
-        .unwrap();
+        let url = Url::parse(&format!("{}/api/users/{}/following", self.inner.endpoint, username)).unwrap();
         self.paginate(url, vec![])
     }
 
     /// List members of an organization.
     /// Endpoint: GET /api/organizations/{organization}/members
-    pub fn list_organization_members(
-        &self,
-        organization: &str,
-    ) -> impl Stream<Item = Result<User>> + '_ {
-        let url = Url::parse(&format!(
-            "{}/api/organizations/{}/members",
-            self.inner.endpoint, organization
-        ))
-        .unwrap();
+    pub fn list_organization_members(&self, organization: &str) -> impl Stream<Item = Result<User>> + '_ {
+        let url = Url::parse(&format!("{}/api/organizations/{}/members", self.inner.endpoint, organization)).unwrap();
         self.paginate(url, vec![])
     }
 }

--- a/huggingface_hub/src/api/webhooks.rs
+++ b/huggingface_hub/src/api/webhooks.rs
@@ -5,13 +5,7 @@ use crate::types::{CreateWebhookParams, UpdateWebhookParams, WebhookInfo};
 impl HfApi {
     pub async fn list_webhooks(&self) -> Result<Vec<WebhookInfo>> {
         let url = format!("{}/api/settings/webhooks", self.inner.endpoint);
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -19,17 +13,8 @@ impl HfApi {
     }
 
     pub async fn get_webhook(&self, webhook_id: &str) -> Result<WebhookInfo> {
-        let url = format!(
-            "{}/api/settings/webhooks/{}",
-            self.inner.endpoint, webhook_id
-        );
-        let response = self
-            .inner
-            .client
-            .get(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/settings/webhooks/{}", self.inner.endpoint, webhook_id);
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -63,10 +48,7 @@ impl HfApi {
     }
 
     pub async fn update_webhook(&self, params: &UpdateWebhookParams) -> Result<WebhookInfo> {
-        let url = format!(
-            "{}/api/settings/webhooks/{}",
-            self.inner.endpoint, params.webhook_id
-        );
+        let url = format!("{}/api/settings/webhooks/{}", self.inner.endpoint, params.webhook_id);
         let mut body = serde_json::Map::new();
         if let Some(ref wh_url) = params.url {
             body.insert("url".into(), serde_json::json!(wh_url));
@@ -95,34 +77,16 @@ impl HfApi {
     }
 
     pub async fn delete_webhook(&self, webhook_id: &str) -> Result<()> {
-        let url = format!(
-            "{}/api/settings/webhooks/{}",
-            self.inner.endpoint, webhook_id
-        );
-        let response = self
-            .inner
-            .client
-            .delete(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/settings/webhooks/{}", self.inner.endpoint, webhook_id);
+        let response = self.inner.client.delete(&url).headers(self.auth_headers()).send().await?;
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(())
     }
 
     pub async fn enable_webhook(&self, webhook_id: &str) -> Result<WebhookInfo> {
-        let url = format!(
-            "{}/api/settings/webhooks/{}/enable",
-            self.inner.endpoint, webhook_id
-        );
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/settings/webhooks/{}/enable", self.inner.endpoint, webhook_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
@@ -130,17 +94,8 @@ impl HfApi {
     }
 
     pub async fn disable_webhook(&self, webhook_id: &str) -> Result<WebhookInfo> {
-        let url = format!(
-            "{}/api/settings/webhooks/{}/disable",
-            self.inner.endpoint, webhook_id
-        );
-        let response = self
-            .inner
-            .client
-            .post(&url)
-            .headers(self.auth_headers())
-            .send()
-            .await?;
+        let url = format!("{}/api/settings/webhooks/{}/disable", self.inner.endpoint, webhook_id);
+        let response = self.inner.client.post(&url).headers(self.auth_headers()).send().await?;
         let response = self
             .check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;

--- a/huggingface_hub/src/blocking.rs
+++ b/huggingface_hub/src/blocking.rs
@@ -21,10 +21,7 @@ impl HfApiSync {
             .enable_all()
             .build()
             .map_err(|e| HfError::Other(format!("Failed to create tokio runtime: {e}")))?;
-        Ok(Self {
-            inner: api,
-            runtime,
-        })
+        Ok(Self { inner: api, runtime })
     }
 
     pub fn api(&self) -> &HfApi {

--- a/huggingface_hub/src/client.rs
+++ b/huggingface_hub/src/client.rs
@@ -1,10 +1,12 @@
-use crate::constants;
-use crate::error::{HfError, Result};
+use std::sync::Arc;
+
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
 use reqwest_middleware::ClientWithMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
-use std::sync::Arc;
+
+use crate::constants;
+use crate::error::{HfError, Result};
 
 pub struct HfApi {
     pub(crate) inner: Arc<HfApiInner>,
@@ -94,15 +96,12 @@ impl HfApiBuilder {
         });
         default_headers.insert(
             USER_AGENT,
-            HeaderValue::from_str(&user_agent)
-                .map_err(|e| HfError::Other(format!("Invalid user agent: {e}")))?,
+            HeaderValue::from_str(&user_agent).map_err(|e| HfError::Other(format!("Invalid user agent: {e}")))?,
         );
 
         let raw_client = match self.client {
             Some(c) => c,
-            None => reqwest::Client::builder()
-                .default_headers(default_headers)
-                .build()?,
+            None => reqwest::Client::builder().default_headers(default_headers).build()?,
         };
 
         let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
@@ -149,11 +148,7 @@ impl HfApi {
     }
 
     /// Build a URL for the API: {endpoint}/api/{segment}/{repo_id}
-    pub(crate) fn api_url(
-        &self,
-        repo_type: Option<crate::types::RepoType>,
-        repo_id: &str,
-    ) -> String {
+    pub(crate) fn api_url(&self, repo_type: Option<crate::types::RepoType>, repo_id: &str) -> String {
         let segment = constants::repo_type_api_segment(repo_type);
         format!("{}/api/{}/{}", self.inner.endpoint, segment, repo_id)
     }
@@ -167,10 +162,7 @@ impl HfApi {
         filename: &str,
     ) -> String {
         let prefix = constants::repo_type_url_prefix(repo_type);
-        format!(
-            "{}/{}{}/resolve/{}/{}",
-            self.inner.endpoint, prefix, repo_id, revision, filename
-        )
+        format!("{}/{}{}/resolve/{}/{}", self.inner.endpoint, prefix, repo_id, revision, filename)
     }
 
     /// Check an HTTP response and map error status codes to HfError variants.
@@ -199,19 +191,15 @@ impl HfApi {
         match status.as_u16() {
             401 => Err(HfError::AuthRequired),
             404 => match not_found_ctx {
-                crate::error::NotFoundContext::Repo => Err(HfError::RepoNotFound {
-                    repo_id: repo_id_str,
-                }),
+                crate::error::NotFoundContext::Repo => Err(HfError::RepoNotFound { repo_id: repo_id_str }),
                 crate::error::NotFoundContext::Entry { path } => Err(HfError::EntryNotFound {
                     path,
                     repo_id: repo_id_str,
                 }),
-                crate::error::NotFoundContext::Revision { revision } => {
-                    Err(HfError::RevisionNotFound {
-                        revision,
-                        repo_id: repo_id_str,
-                    })
-                }
+                crate::error::NotFoundContext::Revision { revision } => Err(HfError::RevisionNotFound {
+                    revision,
+                    repo_id: repo_id_str,
+                }),
                 crate::error::NotFoundContext::Generic => Err(HfError::Http { status, url, body }),
             },
             _ => Err(HfError::Http { status, url, body }),

--- a/huggingface_hub/src/lib.rs
+++ b/huggingface_hub/src/lib.rs
@@ -10,9 +10,7 @@
 //! #[tokio::main]
 //! async fn main() -> huggingface_hub::Result<()> {
 //!     let api = HfApi::new()?;
-//!     let info = api.model_info(
-//!         &ModelInfoParams::builder().repo_id("gpt2").build()
-//!     ).await?;
+//!     let info = api.model_info(&ModelInfoParams::builder().repo_id("gpt2").build()).await?;
 //!     println!("Model: {}", info.id);
 //!     Ok(())
 //! }

--- a/huggingface_hub/src/pagination.rs
+++ b/huggingface_hub/src/pagination.rs
@@ -1,10 +1,12 @@
-use crate::client::HfApi;
-use crate::error::{HfError, Result};
+use std::collections::VecDeque;
+
 use futures::stream::{self, Stream};
 use reqwest::header::HeaderMap;
 use serde::de::DeserializeOwned;
-use std::collections::VecDeque;
 use url::Url;
+
+use crate::client::HfApi;
+use crate::error::{HfError, Result};
 
 struct PaginationState {
     buffer: VecDeque<serde_json::Value>,
@@ -46,11 +48,7 @@ impl HfApi {
                     None => return Ok(None),
                 };
 
-                let mut request = self
-                    .inner
-                    .client
-                    .get(url.clone())
-                    .headers(self.auth_headers());
+                let mut request = self.inner.client.get(url.clone()).headers(self.auth_headers());
                 if state.is_first_page {
                     request = request.query(&params);
                     state.is_first_page = false;
@@ -81,7 +79,7 @@ impl HfApi {
                     Some(raw) => {
                         let item: T = serde_json::from_value(raw)?;
                         Ok(Some((item, state)))
-                    }
+                    },
                     None => Ok(None),
                 }
             }
@@ -109,16 +107,14 @@ fn parse_link_header_next(headers: &HeaderMap) -> Option<Url> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_link_header_next;
     use reqwest::header::{HeaderMap, HeaderValue};
+
+    use super::parse_link_header_next;
 
     #[test]
     fn test_parse_link_header_next() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "link",
-            HeaderValue::from_static(r#"<https://huggingface.co/api/models?p=1>; rel="next""#),
-        );
+        headers.insert("link", HeaderValue::from_static(r#"<https://huggingface.co/api/models?p=1>; rel="next""#));
         let url = parse_link_header_next(&headers).unwrap();
         assert_eq!(url.as_str(), "https://huggingface.co/api/models?p=1");
     }

--- a/huggingface_hub/src/types/commit.rs
+++ b/huggingface_hub/src/types/commit.rs
@@ -1,5 +1,6 @@
-use serde::Deserialize;
 use std::path::PathBuf;
+
+use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CommitAuthor {
@@ -63,10 +64,7 @@ pub struct DiffEntry {
 #[derive(Debug, Clone)]
 pub enum CommitOperation {
     /// Upload a file (from path or bytes)
-    Add {
-        path_in_repo: String,
-        source: AddSource,
-    },
+    Add { path_in_repo: String, source: AddSource },
     /// Delete a file or folder
     Delete { path_in_repo: String },
 }

--- a/huggingface_hub/src/types/jobs.rs
+++ b/huggingface_hub/src/types/jobs.rs
@@ -97,10 +97,7 @@ mod tests {
         }"#;
         let job: JobInfo = serde_json::from_str(json).unwrap();
         assert_eq!(job.id, "abc123");
-        assert_eq!(
-            job.status.as_ref().unwrap().stage.as_deref(),
-            Some("COMPLETED")
-        );
+        assert_eq!(job.status.as_ref().unwrap().stage.as_deref(), Some("COMPLETED"));
     }
 
     #[test]

--- a/huggingface_hub/src/types/mod.rs
+++ b/huggingface_hub/src/types/mod.rs
@@ -22,15 +22,11 @@ pub mod spaces;
 #[cfg(feature = "webhooks")]
 pub mod webhooks;
 
-pub use commit::*;
-pub use params::*;
-pub use repo::*;
-pub use user::*;
-
 #[cfg(feature = "access_requests")]
 pub use access_requests::*;
 #[cfg(feature = "collections")]
 pub use collections::*;
+pub use commit::*;
 #[cfg(feature = "discussions")]
 pub use discussions::*;
 #[cfg(feature = "inference_endpoints")]
@@ -41,7 +37,10 @@ pub use jobs::*;
 pub use likes::*;
 #[cfg(feature = "papers")]
 pub use papers::*;
+pub use params::*;
+pub use repo::*;
 #[cfg(feature = "spaces")]
 pub use spaces::*;
+pub use user::*;
 #[cfg(feature = "webhooks")]
 pub use webhooks::*;

--- a/huggingface_hub/src/types/params.rs
+++ b/huggingface_hub/src/types/params.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
+
+use typed_builder::TypedBuilder;
+
 use super::commit::{AddSource, CommitOperation};
 use super::repo::RepoType;
-use std::path::PathBuf;
-use typed_builder::TypedBuilder;
 
 #[derive(TypedBuilder)]
 pub struct ModelInfoParams {

--- a/huggingface_hub/src/types/repo.rs
+++ b/huggingface_hub/src/types/repo.rs
@@ -1,6 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -31,9 +32,7 @@ impl FromStr for RepoType {
             "dataset" => Ok(RepoType::Dataset),
             "space" => Ok(RepoType::Space),
             "kernel" => Ok(RepoType::Kernel),
-            _ => Err(crate::error::HfError::Other(format!(
-                "Unknown repo type: {s}"
-            ))),
+            _ => Err(crate::error::HfError::Other(format!("Unknown repo type: {s}"))),
         }
     }
 }
@@ -184,7 +183,7 @@ mod tests {
             RepoTreeEntry::File { path, size, .. } => {
                 assert_eq!(path, "test.txt");
                 assert_eq!(size, 100);
-            }
+            },
             _ => panic!("Expected File variant"),
         }
     }
@@ -196,7 +195,7 @@ mod tests {
         match entry {
             RepoTreeEntry::Directory { path, .. } => {
                 assert_eq!(path, "src");
-            }
+            },
             _ => panic!("Expected Directory variant"),
         }
     }

--- a/huggingface_hub/src/xet.rs
+++ b/huggingface_hub/src/xet.rs
@@ -48,15 +48,9 @@ struct HubTokenRefresher {
 #[async_trait::async_trait]
 impl TokenRefresher for HubTokenRefresher {
     async fn refresh(&self) -> std::result::Result<(String, u64), AuthError> {
-        let conn = fetch_xet_connection_info(
-            &self.api,
-            self.token_type,
-            &self.repo_id,
-            self.repo_type,
-            &self.revision,
-        )
-        .await
-        .map_err(|e| AuthError::token_refresh_failure(e.to_string()))?;
+        let conn = fetch_xet_connection_info(&self.api, self.token_type, &self.repo_id, self.repo_type, &self.revision)
+            .await
+            .map_err(|e| AuthError::token_refresh_failure(e.to_string()))?;
         Ok(conn.token_info())
     }
 }
@@ -71,18 +65,9 @@ async fn fetch_xet_connection_info(
     revision: &str,
 ) -> Result<XetConnectionInfo> {
     let segment = constants::repo_type_api_segment(repo_type);
-    let url = format!(
-        "{}/api/{}/{}/xet-{}-token/{}",
-        api.inner.endpoint, segment, repo_id, token_type, revision
-    );
+    let url = format!("{}/api/{}/{}/xet-{}-token/{}", api.inner.endpoint, segment, repo_id, token_type, revision);
 
-    let response = api
-        .inner
-        .client
-        .get(&url)
-        .headers(api.auth_headers())
-        .send()
-        .await?;
+    let response = api.inner.client.get(&url).headers(api.auth_headers()).send().await?;
 
     let response = api
         .check_response(response, Some(repo_id), crate::error::NotFoundContext::Repo)
@@ -118,10 +103,7 @@ pub(crate) async fn xet_download(
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
-    let revision = params
-        .revision
-        .as_deref()
-        .unwrap_or(constants::DEFAULT_REVISION);
+    let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
 
     let session = api
         .get_or_init_xet_session("read", &params.repo_id, params.repo_type, revision)
@@ -167,9 +149,7 @@ pub(crate) async fn xet_upload(
     repo_type: Option<RepoType>,
     revision: &str,
 ) -> Result<Vec<XetFileInfo>> {
-    let session = api
-        .get_or_init_xet_session("write", repo_id, repo_type, revision)
-        .await?;
+    let session = api.get_or_init_xet_session("write", repo_id, repo_type, revision).await?;
 
     let commit = session
         .new_upload_commit()
@@ -240,8 +220,7 @@ impl HfApi {
             }
         }
 
-        let conn =
-            fetch_xet_connection_info(self, token_type, repo_id, repo_type, revision).await?;
+        let conn = fetch_xet_connection_info(self, token_type, repo_id, repo_type, revision).await?;
 
         let token_refresher: Arc<dyn TokenRefresher> = Arc::new(HubTokenRefresher {
             api: self.clone(),
@@ -276,17 +255,7 @@ impl HfApi {
     /// Fetch a Xet connection token (read or write) for a repository.
     /// Endpoint: GET /api/{repo_type}s/{repo_id}/xet-{read|write}-token/{revision}
     pub async fn get_xet_token(&self, params: &GetXetTokenParams) -> Result<XetConnectionInfo> {
-        let revision = params
-            .revision
-            .as_deref()
-            .unwrap_or(constants::DEFAULT_REVISION);
-        fetch_xet_connection_info(
-            self,
-            params.token_type.as_str(),
-            &params.repo_id,
-            params.repo_type,
-            revision,
-        )
-        .await
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        fetch_xet_connection_info(self, params.token_type.as_str(), &params.repo_id, params.repo_type, revision).await
     }
 }

--- a/huggingface_hub/tests/blocking_test.rs
+++ b/huggingface_hub/tests/blocking_test.rs
@@ -20,9 +20,7 @@ fn sync_api() -> Option<HfApiSync> {
 }
 
 fn write_enabled() -> bool {
-    std::env::var("HF_TEST_WRITE")
-        .ok()
-        .is_some_and(|v| v == "1")
+    std::env::var("HF_TEST_WRITE").ok().is_some_and(|v| v == "1")
 }
 
 // --- Repo info ---
@@ -38,9 +36,7 @@ fn test_sync_model_info() {
 #[test]
 fn test_sync_dataset_info() {
     let Some(api) = sync_api() else { return };
-    let params = DatasetInfoParams::builder()
-        .repo_id("rajpurkar/squad")
-        .build();
+    let params = DatasetInfoParams::builder().repo_id("rajpurkar/squad").build();
     let info = api.dataset_info(&params).unwrap();
     assert!(info.id.contains("squad"));
 }
@@ -60,10 +56,7 @@ fn test_sync_repo_exists() {
 #[test]
 fn test_sync_file_exists() {
     let Some(api) = sync_api() else { return };
-    let params = FileExistsParams::builder()
-        .repo_id("gpt2")
-        .filename("config.json")
-        .build();
+    let params = FileExistsParams::builder().repo_id("gpt2").filename("config.json").build();
     assert!(api.file_exists(&params).unwrap());
 
     let params = FileExistsParams::builder()
@@ -78,10 +71,7 @@ fn test_sync_file_exists() {
 #[test]
 fn test_sync_list_models() {
     let Some(api) = sync_api() else { return };
-    let params = ListModelsParams::builder()
-        .author("openai-community")
-        .limit(3_usize)
-        .build();
+    let params = ListModelsParams::builder().author("openai-community").limit(3_usize).build();
     let models = api.list_models(&params).unwrap();
     assert!(!models.is_empty());
     assert!(models[0].id.starts_with("openai-community/"));
@@ -90,10 +80,7 @@ fn test_sync_list_models() {
 #[test]
 fn test_sync_list_datasets() {
     let Some(api) = sync_api() else { return };
-    let params = ListDatasetsParams::builder()
-        .author("huggingface")
-        .limit(3_usize)
-        .build();
+    let params = ListDatasetsParams::builder().author("huggingface").limit(3_usize).build();
     let datasets = api.list_datasets(&params).unwrap();
     assert!(!datasets.is_empty());
 }
@@ -142,10 +129,7 @@ fn test_sync_list_repo_refs() {
 #[test]
 fn test_sync_revision_exists() {
     let Some(api) = sync_api() else { return };
-    let params = RevisionExistsParams::builder()
-        .repo_id("gpt2")
-        .revision("main")
-        .build();
+    let params = RevisionExistsParams::builder().repo_id("gpt2").revision("main").build();
     assert!(api.revision_exists(&params).unwrap());
 
     let params = RevisionExistsParams::builder()
@@ -228,9 +212,7 @@ fn test_sync_list_organization_members() {
 #[test]
 fn test_sync_get_commit_diff() {
     let Some(api) = sync_api() else { return };
-    let commits_params = ListRepoCommitsParams::builder()
-        .repo_id("openai-community/gpt2")
-        .build();
+    let commits_params = ListRepoCommitsParams::builder().repo_id("openai-community/gpt2").build();
     let commits = api.list_repo_commits(&commits_params).unwrap();
     assert!(commits.len() >= 2);
 
@@ -252,11 +234,7 @@ fn uuid_v4_short() -> String {
 
 fn create_test_repo(api: &HfApiSync) -> String {
     let whoami = api.whoami().expect("whoami failed");
-    let repo_id = format!(
-        "{}/huggingface-hub-rust-sync-test-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let repo_id = format!("{}/huggingface-hub-rust-sync-test-{}", whoami.username, uuid_v4_short());
     let params = CreateRepoParams::builder()
         .repo_id(&repo_id)
         .private(true)
@@ -288,11 +266,7 @@ fn test_sync_create_and_delete_repo() {
     }
 
     let whoami = api.whoami().expect("whoami failed");
-    let repo_id = format!(
-        "{}/huggingface-hub-rust-sync-test-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let repo_id = format!("{}/huggingface-hub-rust-sync-test-{}", whoami.username, uuid_v4_short());
 
     let params = CreateRepoParams::builder()
         .repo_id(&repo_id)
@@ -311,10 +285,7 @@ fn test_sync_create_and_delete_repo() {
     let commit = api.upload_file(&params).unwrap();
     assert!(commit.commit_oid.is_some());
 
-    let params = FileExistsParams::builder()
-        .repo_id(&repo_id)
-        .filename("test.txt")
-        .build();
+    let params = FileExistsParams::builder().repo_id(&repo_id).filename("test.txt").build();
     assert!(api.file_exists(&params).unwrap());
 
     let params = DeleteRepoParams::builder().repo_id(&repo_id).build();
@@ -391,20 +362,14 @@ fn test_sync_branch_operations() {
     }
     let repo_id = create_test_repo(&api);
 
-    let create_params = CreateBranchParams::builder()
-        .repo_id(&repo_id)
-        .branch("test-branch")
-        .build();
+    let create_params = CreateBranchParams::builder().repo_id(&repo_id).branch("test-branch").build();
     api.create_branch(&create_params).unwrap();
 
     let refs_params = ListRepoRefsParams::builder().repo_id(&repo_id).build();
     let refs = api.list_repo_refs(&refs_params).unwrap();
     assert!(refs.branches.iter().any(|b| b.name == "test-branch"));
 
-    let delete_params = DeleteBranchParams::builder()
-        .repo_id(&repo_id)
-        .branch("test-branch")
-        .build();
+    let delete_params = DeleteBranchParams::builder().repo_id(&repo_id).branch("test-branch").build();
     api.delete_branch(&delete_params).unwrap();
 
     let refs = api.list_repo_refs(&refs_params).unwrap();

--- a/huggingface_hub/tests/integration_test.rs
+++ b/huggingface_hub/tests/integration_test.rs
@@ -21,9 +21,7 @@ fn api() -> Option<HfApi> {
 }
 
 fn write_enabled() -> bool {
-    std::env::var("HF_TEST_WRITE")
-        .ok()
-        .is_some_and(|v| v == "1")
+    std::env::var("HF_TEST_WRITE").ok().is_some_and(|v| v == "1")
 }
 
 #[tokio::test]
@@ -37,9 +35,7 @@ async fn test_model_info() {
 #[tokio::test]
 async fn test_dataset_info() {
     let Some(api) = api() else { return };
-    let params = DatasetInfoParams::builder()
-        .repo_id("rajpurkar/squad")
-        .build();
+    let params = DatasetInfoParams::builder().repo_id("rajpurkar/squad").build();
     let info = api.dataset_info(&params).await.unwrap();
     assert!(info.id.contains("squad"));
 }
@@ -59,10 +55,7 @@ async fn test_repo_exists() {
 #[tokio::test]
 async fn test_file_exists() {
     let Some(api) = api() else { return };
-    let params = FileExistsParams::builder()
-        .repo_id("gpt2")
-        .filename("config.json")
-        .build();
+    let params = FileExistsParams::builder().repo_id("gpt2").filename("config.json").build();
     assert!(api.file_exists(&params).await.unwrap());
 
     let params = FileExistsParams::builder()
@@ -75,10 +68,7 @@ async fn test_file_exists() {
 #[tokio::test]
 async fn test_list_models() {
     let Some(api) = api() else { return };
-    let params = ListModelsParams::builder()
-        .author("openai-community")
-        .limit(3_usize)
-        .build();
+    let params = ListModelsParams::builder().author("openai-community").limit(3_usize).build();
     let stream = api.list_models(&params);
     futures::pin_mut!(stream);
 
@@ -148,10 +138,7 @@ async fn test_list_repo_refs() {
 #[tokio::test]
 async fn test_revision_exists() {
     let Some(api) = api() else { return };
-    let params = RevisionExistsParams::builder()
-        .repo_id("gpt2")
-        .revision("main")
-        .build();
+    let params = RevisionExistsParams::builder().repo_id("gpt2").revision("main").build();
     assert!(api.revision_exists(&params).await.unwrap());
 
     let params = RevisionExistsParams::builder()
@@ -241,9 +228,7 @@ async fn test_list_organization_members() {
 #[tokio::test]
 async fn test_space_info() {
     let Some(api) = api() else { return };
-    let params = SpaceInfoParams::builder()
-        .repo_id("HuggingFaceFW/blogpost-fineweb-v1")
-        .build();
+    let params = SpaceInfoParams::builder().repo_id("HuggingFaceFW/blogpost-fineweb-v1").build();
     let info = api.space_info(&params).await.unwrap();
     assert!(info.id.contains("blogpost-fineweb-v1"));
 }
@@ -251,10 +236,7 @@ async fn test_space_info() {
 #[tokio::test]
 async fn test_list_datasets() {
     let Some(api) = api() else { return };
-    let params = ListDatasetsParams::builder()
-        .author("huggingface")
-        .limit(3_usize)
-        .build();
+    let params = ListDatasetsParams::builder().author("huggingface").limit(3_usize).build();
     let stream = api.list_datasets(&params);
     futures::pin_mut!(stream);
 
@@ -272,10 +254,7 @@ async fn test_list_datasets() {
 #[tokio::test]
 async fn test_list_spaces() {
     let Some(api) = api() else { return };
-    let params = ListSpacesParams::builder()
-        .author("huggingface")
-        .limit(3_usize)
-        .build();
+    let params = ListSpacesParams::builder().author("huggingface").limit(3_usize).build();
     let stream = api.list_spaces(&params);
     futures::pin_mut!(stream);
 
@@ -318,9 +297,7 @@ async fn test_get_paths_info() {
 async fn test_get_commit_diff() {
     let Some(api) = api() else { return };
 
-    let commits_params = ListRepoCommitsParams::builder()
-        .repo_id("openai-community/gpt2")
-        .build();
+    let commits_params = ListRepoCommitsParams::builder().repo_id("openai-community/gpt2").build();
     let stream = api.list_repo_commits(&commits_params);
     futures::pin_mut!(stream);
 
@@ -339,9 +316,7 @@ async fn test_get_commit_diff() {
 async fn test_get_raw_diff() {
     let Some(api) = api() else { return };
 
-    let commits_params = ListRepoCommitsParams::builder()
-        .repo_id("openai-community/gpt2")
-        .build();
+    let commits_params = ListRepoCommitsParams::builder().repo_id("openai-community/gpt2").build();
     let stream = api.list_repo_commits(&commits_params);
     futures::pin_mut!(stream);
 
@@ -370,11 +345,7 @@ async fn test_create_and_delete_repo() {
         .await
         .expect("whoami should return something, make sure HF_TOKEN is set");
 
-    let repo_id = format!(
-        "{}/huggingface-hub-rust-test-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let repo_id = format!("{}/huggingface-hub-rust-test-{}", whoami.username, uuid_v4_short());
 
     // Create
     let params = CreateRepoParams::builder()
@@ -396,10 +367,7 @@ async fn test_create_and_delete_repo() {
     assert!(commit.commit_oid.is_some());
 
     // Verify file exists
-    let params = FileExistsParams::builder()
-        .repo_id(&repo_id)
-        .filename("test.txt")
-        .build();
+    let params = FileExistsParams::builder().repo_id(&repo_id).filename("test.txt").build();
     assert!(api.file_exists(&params).await.unwrap());
 
     // Delete repo
@@ -415,11 +383,7 @@ fn uuid_v4_short() -> String {
 
 async fn create_test_repo(api: &HfApi) -> String {
     let whoami = api.whoami().await.expect("whoami failed");
-    let repo_id = format!(
-        "{}/huggingface-hub-rust-test-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let repo_id = format!("{}/huggingface-hub-rust-test-{}", whoami.username, uuid_v4_short());
     let params = CreateRepoParams::builder()
         .repo_id(&repo_id)
         .private(true)
@@ -528,10 +492,7 @@ async fn test_delete_file() {
         .build();
     api.delete_file(&params).await.unwrap();
 
-    let exists_params = FileExistsParams::builder()
-        .repo_id(&repo_id)
-        .filename("deleteme.txt")
-        .build();
+    let exists_params = FileExistsParams::builder().repo_id(&repo_id).filename("deleteme.txt").build();
     assert!(!api.file_exists(&exists_params).await.unwrap());
 
     delete_test_repo(&api, &repo_id).await;
@@ -568,10 +529,7 @@ async fn test_delete_folder() {
         .build();
     api.delete_folder(&params).await.unwrap();
 
-    let exists_a = FileExistsParams::builder()
-        .repo_id(&repo_id)
-        .filename("folder/a.txt")
-        .build();
+    let exists_a = FileExistsParams::builder().repo_id(&repo_id).filename("folder/a.txt").build();
     assert!(!api.file_exists(&exists_a).await.unwrap());
 
     delete_test_repo(&api, &repo_id).await;
@@ -585,20 +543,14 @@ async fn test_create_and_delete_branch() {
     }
     let repo_id = create_test_repo(&api).await;
 
-    let create_params = CreateBranchParams::builder()
-        .repo_id(&repo_id)
-        .branch("test-branch")
-        .build();
+    let create_params = CreateBranchParams::builder().repo_id(&repo_id).branch("test-branch").build();
     api.create_branch(&create_params).await.unwrap();
 
     let refs_params = ListRepoRefsParams::builder().repo_id(&repo_id).build();
     let refs = api.list_repo_refs(&refs_params).await.unwrap();
     assert!(refs.branches.iter().any(|b| b.name == "test-branch"));
 
-    let delete_params = DeleteBranchParams::builder()
-        .repo_id(&repo_id)
-        .branch("test-branch")
-        .build();
+    let delete_params = DeleteBranchParams::builder().repo_id(&repo_id).branch("test-branch").build();
     api.delete_branch(&delete_params).await.unwrap();
 
     let refs = api.list_repo_refs(&refs_params).await.unwrap();
@@ -615,20 +567,14 @@ async fn test_create_and_delete_tag() {
     }
     let repo_id = create_test_repo(&api).await;
 
-    let create_params = CreateTagParams::builder()
-        .repo_id(&repo_id)
-        .tag("v1.0")
-        .build();
+    let create_params = CreateTagParams::builder().repo_id(&repo_id).tag("v1.0").build();
     api.create_tag(&create_params).await.unwrap();
 
     let refs_params = ListRepoRefsParams::builder().repo_id(&repo_id).build();
     let refs = api.list_repo_refs(&refs_params).await.unwrap();
     assert!(refs.tags.iter().any(|t| t.name == "v1.0"));
 
-    let delete_params = DeleteTagParams::builder()
-        .repo_id(&repo_id)
-        .tag("v1.0")
-        .build();
+    let delete_params = DeleteTagParams::builder().repo_id(&repo_id).tag("v1.0").build();
     api.delete_tag(&delete_params).await.unwrap();
 
     let refs = api.list_repo_refs(&refs_params).await.unwrap();
@@ -664,27 +610,13 @@ async fn test_move_repo() {
         return;
     }
     let whoami = api.whoami().await.unwrap();
-    let original_name = format!(
-        "{}/huggingface-hub-rust-move-src-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
-    let new_name = format!(
-        "{}/huggingface-hub-rust-move-dst-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let original_name = format!("{}/huggingface-hub-rust-move-src-{}", whoami.username, uuid_v4_short());
+    let new_name = format!("{}/huggingface-hub-rust-move-dst-{}", whoami.username, uuid_v4_short());
 
-    let create_params = CreateRepoParams::builder()
-        .repo_id(&original_name)
-        .private(true)
-        .build();
+    let create_params = CreateRepoParams::builder().repo_id(&original_name).private(true).build();
     api.create_repo(&create_params).await.unwrap();
 
-    let move_params = MoveRepoParams::builder()
-        .from_id(&original_name)
-        .to_id(&new_name)
-        .build();
+    let move_params = MoveRepoParams::builder().from_id(&original_name).to_id(&new_name).build();
     api.move_repo(&move_params).await.unwrap();
 
     let exists_new = RepoExistsParams::builder().repo_id(&new_name).build();
@@ -717,11 +649,7 @@ async fn test_duplicate_space() {
         return;
     }
     let whoami = api.whoami().await.unwrap();
-    let to_id = format!(
-        "{}/hub-rust-test-dup-space-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let to_id = format!("{}/hub-rust-test-dup-space-{}", whoami.username, uuid_v4_short());
 
     let params = DuplicateSpaceParams::builder()
         .from_id("huggingface-projects/diffusers-gallery")
@@ -732,10 +660,7 @@ async fn test_duplicate_space() {
     let result = api.duplicate_space(&params).await.unwrap();
     assert!(result.url.contains(&to_id));
 
-    let delete_params = DeleteRepoParams::builder()
-        .repo_id(&to_id)
-        .repo_type(RepoType::Space)
-        .build();
+    let delete_params = DeleteRepoParams::builder().repo_id(&to_id).repo_type(RepoType::Space).build();
     let _ = api.delete_repo(&delete_params).await;
 }
 
@@ -747,11 +672,7 @@ async fn test_space_secrets_and_variables() {
         return;
     }
     let whoami = api.whoami().await.unwrap();
-    let space_id = format!(
-        "{}/hub-rust-test-space-{}",
-        whoami.username,
-        uuid_v4_short()
-    );
+    let space_id = format!("{}/hub-rust-test-space-{}", whoami.username, uuid_v4_short());
 
     let create_params = CreateRepoParams::builder()
         .repo_id(&space_id)
@@ -768,10 +689,7 @@ async fn test_space_secrets_and_variables() {
         .build();
     api.add_space_secret(&add_secret).await.unwrap();
 
-    let del_secret = DeleteSpaceSecretParams::builder()
-        .repo_id(&space_id)
-        .key("TEST_SECRET")
-        .build();
+    let del_secret = DeleteSpaceSecretParams::builder().repo_id(&space_id).key("TEST_SECRET").build();
     api.delete_space_secret(&del_secret).await.unwrap();
 
     let add_var = AddSpaceVariableParams::builder()
@@ -781,10 +699,7 @@ async fn test_space_secrets_and_variables() {
         .build();
     api.add_space_variable(&add_var).await.unwrap();
 
-    let del_var = DeleteSpaceVariableParams::builder()
-        .repo_id(&space_id)
-        .key("TEST_VAR")
-        .build();
+    let del_var = DeleteSpaceVariableParams::builder().repo_id(&space_id).key("TEST_VAR").build();
     api.delete_space_variable(&del_var).await.unwrap();
 
     let delete_params = DeleteRepoParams::builder()
@@ -816,10 +731,7 @@ async fn test_list_inference_endpoints() {
 #[tokio::test]
 async fn test_list_collections() {
     let Some(api) = api() else { return };
-    let params = ListCollectionsParams::builder()
-        .owner("huggingface")
-        .limit(3_usize)
-        .build();
+    let params = ListCollectionsParams::builder().owner("huggingface").limit(3_usize).build();
     let collections = api.list_collections(&params).await.unwrap();
     assert!(!collections.is_empty());
     assert!(collections[0].slug.contains("huggingface"));
@@ -829,16 +741,11 @@ async fn test_list_collections() {
 #[tokio::test]
 async fn test_get_collection() {
     let Some(api) = api() else { return };
-    let list_params = ListCollectionsParams::builder()
-        .owner("huggingface")
-        .limit(1_usize)
-        .build();
+    let list_params = ListCollectionsParams::builder().owner("huggingface").limit(1_usize).build();
     let collections = api.list_collections(&list_params).await.unwrap();
     assert!(!collections.is_empty());
 
-    let params = GetCollectionParams::builder()
-        .slug(&collections[0].slug)
-        .build();
+    let params = GetCollectionParams::builder().slug(&collections[0].slug).build();
     let coll = api.get_collection(&params).await.unwrap();
     assert_eq!(coll.slug, collections[0].slug);
 }
@@ -878,9 +785,7 @@ async fn test_create_update_delete_collection() {
 #[tokio::test]
 async fn test_get_repo_discussions() {
     let Some(api) = api() else { return };
-    let params = GetRepoDiscussionsParams::builder()
-        .repo_id("openai-community/gpt2")
-        .build();
+    let params = GetRepoDiscussionsParams::builder().repo_id("openai-community/gpt2").build();
     let response = api.get_repo_discussions(&params).await.unwrap();
     assert!(!response.discussions.is_empty());
     assert!(response.discussions[0].num > 0);
@@ -909,11 +814,7 @@ async fn test_create_discussion_and_comment() {
     let repo_id = create_test_repo(&api).await;
 
     let disc_response = api
-        .get_repo_discussions(
-            &GetRepoDiscussionsParams::builder()
-                .repo_id(&repo_id)
-                .build(),
-        )
+        .get_repo_discussions(&GetRepoDiscussionsParams::builder().repo_id(&repo_id).build())
         .await
         .unwrap();
     let initial_count = disc_response.discussions.len();
@@ -926,11 +827,7 @@ async fn test_create_discussion_and_comment() {
     let _disc = api.create_discussion(&create_params).await.unwrap();
 
     let disc_response = api
-        .get_repo_discussions(
-            &GetRepoDiscussionsParams::builder()
-                .repo_id(&repo_id)
-                .build(),
-        )
+        .get_repo_discussions(&GetRepoDiscussionsParams::builder().repo_id(&repo_id).build())
         .await
         .unwrap();
     assert!(disc_response.discussions.len() > initial_count);
@@ -955,17 +852,10 @@ async fn test_create_and_merge_pull_request() {
     let _pr = api.create_pull_request(&pr_params).await.unwrap();
 
     let disc_response = api
-        .get_repo_discussions(
-            &GetRepoDiscussionsParams::builder()
-                .repo_id(&repo_id)
-                .build(),
-        )
+        .get_repo_discussions(&GetRepoDiscussionsParams::builder().repo_id(&repo_id).build())
         .await
         .unwrap();
-    assert!(disc_response
-        .discussions
-        .iter()
-        .any(|d| d.is_pull_request == Some(true)));
+    assert!(disc_response.discussions.iter().any(|d| d.is_pull_request == Some(true)));
 
     delete_test_repo(&api, &repo_id).await;
 }
@@ -1000,9 +890,7 @@ async fn test_create_and_delete_webhook() {
     let whoami = api.whoami().await.unwrap();
     let create_params = CreateWebhookParams::builder()
         .url("https://example.com/test-webhook")
-        .watched(vec![
-            serde_json::json!({"type": "user", "name": whoami.username}),
-        ])
+        .watched(vec![serde_json::json!({"type": "user", "name": whoami.username})])
         .domains(vec!["repo".to_string()])
         .build();
     let webhook = api.create_webhook(&create_params).await.unwrap();
@@ -1016,13 +904,10 @@ async fn test_create_and_delete_webhook() {
         let newest = after_create
             .iter()
             .find(|w| {
-                w.url.as_deref() == Some("https://example.com/test-webhook")
-                    && !initial.iter().any(|i| i.id == w.id)
+                w.url.as_deref() == Some("https://example.com/test-webhook") && !initial.iter().any(|i| i.id == w.id)
             })
             .expect("should find newly created webhook");
-        api.delete_webhook(newest.id.as_ref().unwrap())
-            .await
-            .unwrap();
+        api.delete_webhook(newest.id.as_ref().unwrap()).await.unwrap();
     }
 }
 
@@ -1092,15 +977,10 @@ async fn test_list_access_requests_on_gated_repo() {
     }
     let repo_id = create_test_repo(&api).await;
 
-    let update_params = UpdateRepoParams::builder()
-        .repo_id(&repo_id)
-        .gated("auto")
-        .build();
+    let update_params = UpdateRepoParams::builder().repo_id(&repo_id).gated("auto").build();
     api.update_repo_settings(&update_params).await.unwrap();
 
-    let params = ListAccessRequestsParams::builder()
-        .repo_id(&repo_id)
-        .build();
+    let params = ListAccessRequestsParams::builder().repo_id(&repo_id).build();
     let pending = api.list_pending_access_requests(&params).await.unwrap();
     assert!(pending.is_empty());
 
@@ -1122,9 +1002,7 @@ async fn test_list_access_requests_on_gated_repo() {
 #[tokio::test]
 async fn test_list_repo_likers() {
     let Some(api) = api() else { return };
-    let params = ListRepoLikersParams::builder()
-        .repo_id("openai-community/gpt2")
-        .build();
+    let params = ListRepoLikersParams::builder().repo_id("openai-community/gpt2").build();
     let stream = api.list_repo_likers(&params);
     futures::pin_mut!(stream);
 
@@ -1151,9 +1029,7 @@ async fn test_like_and_unlike() {
     }
 
     let whoami = api.whoami().await.unwrap();
-    let list_params = ListLikedReposParams::builder()
-        .username(&whoami.username)
-        .build();
+    let list_params = ListLikedReposParams::builder().username(&whoami.username).build();
     let likes = api.list_liked_repos(&list_params).await.unwrap();
     assert!(likes.iter().any(|l| {
         l.repo
@@ -1184,10 +1060,7 @@ async fn test_paper_info() {
 #[tokio::test]
 async fn test_list_papers() {
     let Some(api) = api() else { return };
-    let params = ListPapersParams::builder()
-        .query("attention")
-        .limit(5_usize)
-        .build();
+    let params = ListPapersParams::builder().query("attention").limit(5_usize).build();
     let results = api.list_papers(&params).await.unwrap();
     assert!(!results.is_empty());
     assert!(results[0].paper.is_some());
@@ -1197,10 +1070,7 @@ async fn test_list_papers() {
 #[tokio::test]
 async fn test_list_daily_papers() {
     let Some(api) = api() else { return };
-    let params = ListDailyPapersParams::builder()
-        .date("2024-10-29")
-        .limit(5_usize)
-        .build();
+    let params = ListDailyPapersParams::builder().date("2024-10-29").limit(5_usize).build();
     let papers = api.list_daily_papers(&params).await.unwrap();
     assert!(!papers.is_empty());
     assert!(papers[0].paper.is_some());

--- a/huggingface_hub/tests/xet_transfer_test.rs
+++ b/huggingface_hub/tests/xet_transfer_test.rs
@@ -8,19 +8,20 @@
 //!   - HF_TEST_WRITE=1 (creates and deletes repos)
 //!   - Compiled with --features xet
 //!
-//! Run: source ~/hf/prod_token && HF_TEST_WRITE=1 cargo test -p huggingface-hub --features xet --test xet_transfer_test -- --nocapture
+//! Run: source ~/hf/prod_token && HF_TEST_WRITE=1 cargo test -p huggingface-hub --features xet --test xet_transfer_test
+//! -- --nocapture
 //!
 //! These tests are slow (uploading large files) and create real repositories.
 
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use huggingface_hub::types::{
-    AddSource, CreateRepoParams, DeleteRepoParams, DownloadFileParams, FileExistsParams,
-    UploadFileParams,
+    AddSource, CreateRepoParams, DeleteRepoParams, DownloadFileParams, FileExistsParams, UploadFileParams,
 };
 use huggingface_hub::{HfApi, HfApiBuilder};
 use rand::Rng;
 use sha2::{Digest, Sha256};
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn api() -> Option<HfApi> {
     if std::env::var("HF_TOKEN").is_err() {
@@ -30,9 +31,7 @@ fn api() -> Option<HfApi> {
 }
 
 fn write_enabled() -> bool {
-    std::env::var("HF_TEST_WRITE")
-        .ok()
-        .is_some_and(|v| v == "1")
+    std::env::var("HF_TEST_WRITE").ok().is_some_and(|v| v == "1")
 }
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -258,14 +257,14 @@ async fn test_download_from_known_xet_repo() {
             assert!(path.exists());
             let metadata = std::fs::metadata(&path).unwrap();
             assert!(metadata.len() > 0);
-        }
+        },
         Err(e) => {
             let err_str = e.to_string();
             assert!(
                 err_str.contains("not found") || err_str.contains("Not Found"),
                 "Expected success or not-found for xet repo, got: {err_str}"
             );
-        }
+        },
     }
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,13 @@
+format_code_in_doc_comments = true
+wrap_comments = true
+reorder_imports = true
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+imports_layout = "Mixed"
+match_block_trailing_comma = true
+comment_width = 120
+max_width = 120
+fn_call_width = 100
+chain_width = 80
+use_field_init_shorthand = true


### PR DESCRIPTION
## Summary
- Add `rustfmt.toml` with opinionated formatting rules (120 char width, grouped imports, trailing commas in match blocks, doc comment formatting, etc.)
- Reformat entire codebase with `cargo +nightly fmt --all`
- Update CI fmt job to use `--all` flag

## Test plan
- [ ] CI fmt check passes
- [ ] CI clippy passes
- [ ] CI build and tests pass