### PR TITLE
feat: add download_file_stream and download/upload example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build -p huggingface-hub --release
+      - run: cargo build -p huggingface-hub --all-features --examples
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "fs4",
  "futures",
  "globset",

--- a/huggingface_hub/Cargo.toml
+++ b/huggingface_hub/Cargo.toml
@@ -6,6 +6,7 @@ description = "Rust client for the Hugging Face Hub API"
 license = "Apache-2.0"
 
 [dependencies]
+bytes = "1"
 reqwest = { version = "0.13", features = ["json", "stream", "multipart"] }
 reqwest-middleware = { version = "0.5", features = ["json", "multipart", "query"] }
 reqwest-retry = "0.9"
@@ -106,6 +107,10 @@ required-features = ["likes"]
 name = "papers"
 path = "examples/papers.rs"
 required-features = ["papers"]
+
+[[example]]
+name = "download_upload"
+path = "examples/download_upload.rs"
 
 [[example]]
 name = "blocking_read"

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -74,6 +74,25 @@ async fn main() -> huggingface_hub::Result<()> {
     file.flush().await?;
     println!("Streamed {total} bytes to {}", stream_dest.display());
 
+    // --- Download as stream and process in memory ---
+
+    let (_content_length, mut stream) = api
+        .download_file_stream(
+            &DownloadFileStreamParams::builder()
+                .repo_id("openai-community/gpt2")
+                .filename("config.json")
+                .build(),
+        )
+        .await?;
+
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        buf.extend_from_slice(&chunk?);
+    }
+
+    let config: serde_json::Value = serde_json::from_slice(&buf)?;
+    println!("Parsed config in memory: model_type={}, vocab_size={}", config["model_type"], config["vocab_size"]);
+
     // --- Upload (requires HF_TOKEN and HF_TEST_WRITE=1) ---
 
     if std::env::var("HF_TOKEN").is_err() || std::env::var("HF_TEST_WRITE").is_err() {

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -34,6 +34,20 @@ async fn main() -> huggingface_hub::Result<()> {
         .await?;
     println!("Downloaded to cache: {}", cached_path.display());
 
+    // --- Download a large xet-backed file to local directory ---
+
+    let xet_path = api
+        .download_file(
+            &DownloadFileParams::builder()
+                .repo_id("Lightricks/LTX-2.3")
+                .filename("ltx-2.3-spatial-upscaler-x1.5-1.0.safetensors")
+                .local_dir(tmp_dir.path().to_path_buf())
+                .build(),
+        )
+        .await?;
+    let xet_size = std::fs::metadata(&xet_path).map(|m| m.len()).unwrap_or(0);
+    println!("Downloaded xet file to: {} ({xet_size} bytes)", xet_path.display());
+
     // --- Download to local directory ---
 
     let local_path = api

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -13,7 +13,7 @@
 use futures::StreamExt;
 use huggingface_hub::{
     AddSource, CreateRepoParams, DeleteRepoParams, DownloadFileParams, DownloadFileStreamParams, HfApi,
-    UploadFileParams,
+    SnapshotDownloadParams, UploadFileParams,
 };
 use tokio::io::AsyncWriteExt;
 
@@ -92,6 +92,24 @@ async fn main() -> huggingface_hub::Result<()> {
 
     let config: serde_json::Value = serde_json::from_slice(&buf)?;
     println!("Parsed config in memory: model_type={}, vocab_size={}", config["model_type"], config["vocab_size"]);
+
+    // --- Download a folder (snapshot) ---
+
+    let snapshot_dir = tmp_dir.path().join("snapshot");
+    let snapshot_path = api
+        .snapshot_download(
+            &SnapshotDownloadParams::builder()
+                .repo_id("openai-community/gpt2")
+                .local_dir(snapshot_dir)
+                .allow_patterns(vec!["*.json".to_string()])
+                .build(),
+        )
+        .await?;
+    println!("Downloaded snapshot to: {}", snapshot_path.display());
+    for entry in std::fs::read_dir(&snapshot_path)? {
+        let entry = entry?;
+        println!("  {}", entry.file_name().to_string_lossy());
+    }
 
     // --- Upload (requires HF_TOKEN and HF_TEST_WRITE=1) ---
 

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -13,7 +13,7 @@
 use futures::StreamExt;
 use huggingface_hub::{
     AddSource, CreateRepoParams, DeleteRepoParams, DownloadFileParams, DownloadFileStreamParams, HfApi,
-    SnapshotDownloadParams, UploadFileParams,
+    SnapshotDownloadParams, UploadFileParams, UploadFolderParams,
 };
 use tokio::io::AsyncWriteExt;
 
@@ -159,6 +159,24 @@ async fn main() -> huggingface_hub::Result<()> {
         )
         .await?;
     println!("Uploaded data/local_data.txt: {:?}", commit.commit_url);
+
+    // Upload a folder
+    let upload_dir = tmp_dir.path().join("my_folder");
+    std::fs::create_dir_all(upload_dir.join("subdir")).expect("failed to create dirs");
+    std::fs::write(upload_dir.join("root.txt"), "root file").expect("failed to write");
+    std::fs::write(upload_dir.join("subdir/nested.txt"), "nested file").expect("failed to write");
+
+    let commit = api
+        .upload_folder(
+            &UploadFolderParams::builder()
+                .repo_id(&repo_name)
+                .folder_path(upload_dir)
+                .path_in_repo("uploaded")
+                .commit_message("Upload folder with nested files")
+                .build(),
+        )
+        .await?;
+    println!("Uploaded folder: {:?}", commit.commit_url);
 
     // Cleanup
     api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -1,0 +1,119 @@
+//! Download and upload files from/to the Hugging Face Hub.
+//!
+//! Demonstrates:
+//! - Downloading a file to a local directory
+//! - Downloading a file as a byte stream
+//! - Uploading a file from bytes
+//! - Uploading a file from a local path
+//!
+//! Read operations require no auth. Write operations require HF_TOKEN.
+//! Run: cargo run -p huggingface-hub --example download_upload
+
+use futures::StreamExt;
+use huggingface_hub::{
+    AddSource, CreateRepoParams, DeleteRepoParams, DownloadFileParams, DownloadFileStreamParams, HfApi,
+    UploadFileParams,
+};
+use tokio::io::AsyncWriteExt;
+
+#[tokio::main]
+async fn main() -> huggingface_hub::Result<()> {
+    let api = HfApi::new()?;
+    let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    // --- Download to file ---
+
+    let path = api
+        .download_file(
+            &DownloadFileParams::builder()
+                .repo_id("gpt2")
+                .filename("config.json")
+                .local_dir(tmp_dir.path().to_path_buf())
+                .build(),
+        )
+        .await?;
+    let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    println!("Downloaded gpt2/config.json to {} ({size} bytes)", path.display());
+
+    // --- Download as stream ---
+
+    let (content_length, mut stream) = api
+        .download_file_stream(
+            &DownloadFileStreamParams::builder()
+                .repo_id("gpt2")
+                .filename("config.json")
+                .build(),
+        )
+        .await?;
+    println!(
+        "Streaming gpt2/config.json (content-length: {})",
+        content_length.map_or("unknown".to_string(), |n| format!("{n}"))
+    );
+
+    let stream_dest = tmp_dir.path().join("config_streamed.json");
+    let mut file = tokio::fs::File::create(&stream_dest).await?;
+    let mut total = 0u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        total += chunk.len() as u64;
+        file.write_all(&chunk).await?;
+    }
+    file.flush().await?;
+    println!("Streamed {total} bytes to {}", stream_dest.display());
+
+    // --- Upload (requires HF_TOKEN and HF_TEST_WRITE=1) ---
+
+    if std::env::var("HF_TOKEN").is_err() || std::env::var("HF_TEST_WRITE").is_err() {
+        println!("\nSkipping upload examples (set HF_TOKEN and HF_TEST_WRITE=1 to run)");
+        return Ok(());
+    }
+
+    let user = api.whoami().await?;
+    let repo_name = format!("{}/example-download-upload-{}", user.username, std::process::id());
+
+    api.create_repo(
+        &CreateRepoParams::builder()
+            .repo_id(&repo_name)
+            .private(true)
+            .exist_ok(true)
+            .build(),
+    )
+    .await?;
+    println!("\nCreated repo: {repo_name}");
+
+    // Upload from bytes
+    let commit = api
+        .upload_file(
+            &UploadFileParams::builder()
+                .repo_id(&repo_name)
+                .source(AddSource::Bytes(b"Hello from Rust!".to_vec()))
+                .path_in_repo("hello.txt")
+                .commit_message("Add hello.txt from bytes")
+                .build(),
+        )
+        .await?;
+    println!("Uploaded hello.txt: {:?}", commit.commit_url);
+
+    // Upload from local file
+    let local_file = tmp_dir.path().join("local_data.txt");
+    std::fs::write(&local_file, "Data from a local file").expect("failed to write local file");
+
+    let commit = api
+        .upload_file(
+            &UploadFileParams::builder()
+                .repo_id(&repo_name)
+                .source(AddSource::File(local_file))
+                .path_in_repo("data/local_data.txt")
+                .commit_message("Add local_data.txt from file path")
+                .build(),
+        )
+        .await?;
+    println!("Uploaded data/local_data.txt: {:?}", commit.commit_url);
+
+    // Cleanup
+    api.delete_repo(&DeleteRepoParams::builder().repo_id(&repo_name).missing_ok(true).build())
+        .await?;
+    println!("Cleaned up repo: {repo_name}");
+
+    Ok(())
+}

--- a/huggingface_hub/examples/download_upload.rs
+++ b/huggingface_hub/examples/download_upload.rs
@@ -1,6 +1,7 @@
 //! Download and upload files from/to the Hugging Face Hub.
 //!
 //! Demonstrates:
+//! - Downloading a file to the HF cache
 //! - Downloading a file to a local directory
 //! - Downloading a file as a byte stream
 //! - Uploading a file from bytes
@@ -21,32 +22,44 @@ async fn main() -> huggingface_hub::Result<()> {
     let api = HfApi::new()?;
     let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
 
-    // --- Download to file ---
+    // --- Download to HF cache ---
 
-    let path = api
+    let cached_path = api
         .download_file(
             &DownloadFileParams::builder()
-                .repo_id("gpt2")
+                .repo_id("openai-community/gpt2")
+                .filename("config.json")
+                .build(),
+        )
+        .await?;
+    println!("Downloaded to cache: {}", cached_path.display());
+
+    // --- Download to local directory ---
+
+    let local_path = api
+        .download_file(
+            &DownloadFileParams::builder()
+                .repo_id("openai-community/gpt2")
                 .filename("config.json")
                 .local_dir(tmp_dir.path().to_path_buf())
                 .build(),
         )
         .await?;
-    let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-    println!("Downloaded gpt2/config.json to {} ({size} bytes)", path.display());
+    let size = std::fs::metadata(&local_path).map(|m| m.len()).unwrap_or(0);
+    println!("Downloaded to local dir: {} ({size} bytes)", local_path.display());
 
     // --- Download as stream ---
 
     let (content_length, mut stream) = api
         .download_file_stream(
             &DownloadFileStreamParams::builder()
-                .repo_id("gpt2")
+                .repo_id("openai-community/gpt2")
                 .filename("config.json")
                 .build(),
         )
         .await?;
     println!(
-        "Streaming gpt2/config.json (content-length: {})",
+        "Streaming config.json (content-length: {})",
         content_length.map_or("unknown".to_string(), |n| format!("{n}"))
     );
 

--- a/huggingface_hub/src/api/files.rs
+++ b/huggingface_hub/src/api/files.rs
@@ -10,9 +10,9 @@ use crate::client::HfApi;
 use crate::error::{HfError, Result};
 use crate::types::{
     AddSource, CommitInfo, CommitOperation, CreateCommitParams, DatasetInfoParams, DeleteFileParams,
-    DeleteFolderParams, DownloadFileParams, GetPathsInfoParams, ListRepoFilesParams, ListRepoTreeParams,
-    ModelInfoParams, RepoTreeEntry, RepoType, SnapshotDownloadParams, SpaceInfoParams, UploadFileParams,
-    UploadFolderParams,
+    DeleteFolderParams, DownloadFileParams, DownloadFileStreamParams, GetPathsInfoParams, ListRepoFilesParams,
+    ListRepoTreeParams, ModelInfoParams, RepoTreeEntry, RepoType, SnapshotDownloadParams, SpaceInfoParams,
+    UploadFileParams, UploadFolderParams,
 };
 use crate::{cache, constants};
 
@@ -107,6 +107,34 @@ impl HfApi {
             }
             self.download_file_to_cache(params).await
         }
+    }
+
+    /// Download a file and return a byte stream instead of writing to disk.
+    ///
+    /// Returns a `(content_length, stream)` tuple. `content_length` is `Some`
+    /// when the server provides a `Content-Length` header.
+    ///
+    /// Endpoint: GET {endpoint}/{prefix}{repo_id}/resolve/{revision}/{filename}
+    pub async fn download_file_stream(
+        &self,
+        params: &DownloadFileStreamParams,
+    ) -> Result<(Option<u64>, impl Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>>)> {
+        let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let url = self.download_url(params.repo_type, &params.repo_id, revision, &params.filename);
+
+        let response = self.inner.client.get(&url).headers(self.auth_headers()).send().await?;
+        let response = self
+            .check_response(
+                response,
+                Some(&params.repo_id),
+                crate::error::NotFoundContext::Entry {
+                    path: params.filename.clone(),
+                },
+            )
+            .await?;
+
+        let content_length = response.content_length();
+        Ok((content_length, response.bytes_stream()))
     }
 
     async fn download_file_to_local_dir(&self, params: &DownloadFileParams) -> Result<PathBuf> {

--- a/huggingface_hub/src/types/params.rs
+++ b/huggingface_hub/src/types/params.rs
@@ -215,6 +215,18 @@ pub struct DownloadFileParams {
 }
 
 #[derive(TypedBuilder)]
+pub struct DownloadFileStreamParams {
+    #[builder(setter(into))]
+    pub repo_id: String,
+    #[builder(setter(into))]
+    pub filename: String,
+    #[builder(default, setter(into, strip_option))]
+    pub repo_type: Option<RepoType>,
+    #[builder(default, setter(into, strip_option))]
+    pub revision: Option<String>,
+}
+
+#[derive(TypedBuilder)]
 pub struct SnapshotDownloadParams {
     #[builder(setter(into))]
     pub repo_id: String,


### PR DESCRIPTION
## Summary
- Adds `HfApi::download_file_stream` method that returns a `(Option<u64>, impl Stream<Item = Result<bytes::Bytes>>)` tuple for streaming file downloads without writing to disk
- Adds `DownloadFileStreamParams` param struct with `repo_id`, `filename`, optional `repo_type`/`revision`
- Adds `download_upload` example demonstrating:
  - Download to file via `download_file`
  - Download as byte stream via `download_file_stream`
  - Upload from bytes via `upload_file` with `AddSource::Bytes`
  - Upload from local file path via `upload_file` with `AddSource::File`

## Test plan
- [x] `cargo check -p huggingface-hub` passes
- [x] `cargo clippy -p huggingface-hub -- -D warnings` passes
- [x] `cargo build -p huggingface-hub --release --example download_upload` builds
- [x] Run example read-only: `cargo run -p huggingface-hub --example download_upload`
- [x] Run example with writes: `HF_TOKEN=hf_xxx HF_TEST_WRITE=1 cargo run -p huggingface-hub --example download_upload`