### PR TITLE
Upgrade xet-core integration to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,68 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "bandwidth"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a464cd54c99441ba44d3d09f6f980f8c29d068645022852ab66cbaad42ef6a0"
-dependencies = [
- "rustversion",
- "serde",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,20 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "duration-str"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12494809f9915b6132014cc259c4e204ab53ab6c6dd2225672703b5359267d82"
-dependencies = [
- "chrono",
- "rust_decimal",
- "serde",
- "thiserror 2.0.18",
- "time",
- "winnow",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,12 +659,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs4"
@@ -961,17 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if 1.0.4",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,30 +892,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
 
 [[package]]
 name = "heapify"
@@ -1063,15 +946,16 @@ dependencies = [
 [[package]]
 name = "hf-xet"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=749c28b#749c28b086d78ac64338819d13f420714ba13ce8"
+source = "git+https://github.com/huggingface/xet-core.git?rev=86935b4117672f2edfeeb342388934382980b5eb#86935b4117672f2edfeeb342388934382980b5eb"
 dependencies = [
- "anyhow",
  "async-trait",
+ "bytes",
  "http",
  "more-asserts",
  "serde",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "ulid",
  "xet-client",
@@ -1120,12 +1004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "huggingface-hub"
 version = "0.1.0"
 dependencies = [
@@ -1154,13 +1032,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-bandwidth"
-version = "0.1.4"
+name = "humantime"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5afe042873d564e1fccc5d50983e1e6341ffcae8fb7603c6c542de7129a785"
-dependencies = [
- "bandwidth",
-]
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1176,7 +1051,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1485,12 +1359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,22 +1430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,53 +1463,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
-dependencies = [
- "cfg-if 1.0.4",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
-dependencies = [
- "cfg-if 1.0.4",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
-
-[[package]]
-name = "nalgebra"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.5",
- "rand_distr",
- "simba",
- "typenum",
-]
 
 [[package]]
 name = "ntapi"
@@ -1678,49 +1487,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1729,7 +1499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1831,12 +1600,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -2165,22 +1928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,16 +2081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
-dependencies = [
- "arrayvec",
- "num-traits",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,15 +2193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,12 +2218,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2582,17 +2304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,17 +2350,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2759,9 +2459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx",
- "nalgebra",
  "num-traits",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -3059,7 +2757,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3098,7 +2795,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3330,35 +3026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "warp"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-util",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,16 +3227,6 @@ dependencies = [
  "objc2-system-configuration",
  "wasite",
  "web-sys",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -3882,15 +3539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,27 +3635,21 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "xet-client"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=749c28b#749c28b086d78ac64338819d13f420714ba13ce8"
+source = "git+https://github.com/huggingface/xet-core.git?rev=86935b4117672f2edfeeb342388934382980b5eb#86935b4117672f2edfeeb342388934382980b5eb"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "base64",
  "bytes",
  "clap",
  "crc32fast",
  "derivative",
- "duration-str",
  "futures",
- "futures-util",
  "heed",
  "http",
- "human-bandwidth",
  "hyper",
  "lazy_static",
- "mockall",
  "more-asserts",
- "once_cell",
  "rand 0.9.2",
  "reqwest",
  "reqwest-middleware",
@@ -4020,12 +3662,10 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
  "urlencoding",
- "warp",
  "web-time",
  "xet-core-structures",
  "xet-runtime",
@@ -4034,11 +3674,10 @@ dependencies = [
 [[package]]
 name = "xet-core-structures"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=749c28b#749c28b086d78ac64338819d13f420714ba13ce8"
+source = "git+https://github.com/huggingface/xet-core.git?rev=86935b4117672f2edfeeb342388934382980b5eb#86935b4117672f2edfeeb342388934382980b5eb"
 dependencies = [
  "async-trait",
  "base64",
- "bincode",
  "blake3",
  "bytemuck",
  "bytes",
@@ -4048,9 +3687,7 @@ dependencies = [
  "futures",
  "futures-util",
  "getrandom 0.4.2",
- "half",
  "heapify",
- "heed",
  "itertools",
  "lazy_static",
  "lz4_flex",
@@ -4073,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "xet-data"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=749c28b#749c28b086d78ac64338819d13f420714ba13ce8"
+source = "git+https://github.com/huggingface/xet-core.git?rev=86935b4117672f2edfeeb342388934382980b5eb#86935b4117672f2edfeeb342388934382980b5eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4087,7 +3724,6 @@ dependencies = [
  "more-asserts",
  "prometheus",
  "rand 0.9.2",
- "regex",
  "serde",
  "serde_json",
  "sha2",
@@ -4107,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "xet-runtime"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=749c28b#749c28b086d78ac64338819d13f420714ba13ce8"
+source = "git+https://github.com/huggingface/xet-core.git?rev=86935b4117672f2edfeeb342388934382980b5eb#86935b4117672f2edfeeb342388934382980b5eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4117,10 +3753,9 @@ dependencies = [
  "const-str",
  "ctor",
  "dirs",
- "duration-str",
  "futures",
- "futures-util",
  "git-version",
+ "humantime",
  "konst",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,12 +446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,12 +553,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "doxygen-rs"
@@ -1712,32 +1700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,19 +2362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,12 +2521,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/huggingface_hub/Cargo.toml
+++ b/huggingface_hub/Cargo.toml
@@ -22,8 +22,8 @@ base64 = "0.22"
 fs4 = { version = "0.13", features = ["tokio"] }
 pathdiff = "0.2"
 async-trait = { version = "0.1", optional = true }
-hf-xet = { git = "https://github.com/huggingface/xet-core.git", rev = "749c28b", optional = true }
-xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "749c28b", optional = true }
+hf-xet = { git = "https://github.com/huggingface/xet-core.git", rev = "86935b4117672f2edfeeb342388934382980b5eb", optional = true }
+xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "86935b4117672f2edfeeb342388934382980b5eb", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 [features]

--- a/huggingface_hub/src/client.rs
+++ b/huggingface_hub/src/client.rs
@@ -27,7 +27,13 @@ pub(crate) struct HfApiInner {
     pub(crate) cache_dir: std::path::PathBuf,
     pub(crate) cache_enabled: bool,
     #[cfg(feature = "xet")]
-    pub(crate) xet_session: std::sync::Mutex<Option<xet::xet_session::XetSession>>,
+    pub(crate) xet_session: std::sync::Mutex<Option<CachedXetSession>>,
+}
+
+#[cfg(feature = "xet")]
+pub(crate) struct CachedXetSession {
+    pub(crate) endpoint: String,
+    pub(crate) session: xet::xet_session::XetSession,
 }
 
 pub struct HfApiBuilder {

--- a/huggingface_hub/src/xet.rs
+++ b/huggingface_hub/src/xet.rs
@@ -5,13 +5,11 @@
 //! is not enabled, HfError::XetNotEnabled is returned at the call site.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use serde::Deserialize;
-use xet::xet_session::{FileMetadata, Sha256Policy, XetFileInfo, XetSessionBuilder};
-use xet_client::cas_client::auth::{AuthError, TokenRefresher};
+use xet::xet_session::{Sha256Policy, XetFileInfo, XetSessionBuilder};
 
-use crate::client::HfApi;
+use crate::client::{CachedXetSession, HfApi};
 use crate::constants;
 use crate::error::{HfError, Result};
 use crate::types::{AddSource, GetXetTokenParams, RepoType};
@@ -36,23 +34,83 @@ impl XetConnectionInfo {
     }
 }
 
-/// Implements token refresh by calling the Hub API's xet token endpoint.
-struct HubTokenRefresher {
-    api: HfApi,
-    repo_id: String,
-    repo_type: Option<RepoType>,
-    revision: String,
-    token_type: &'static str,
+struct XetOperationConfig {
+    session: xet::xet_session::XetSession,
+    token: String,
+    expiry: u64,
+    refresh_url: String,
+    refresh_headers: reqwest::header::HeaderMap,
 }
 
-#[async_trait::async_trait]
-impl TokenRefresher for HubTokenRefresher {
-    async fn refresh(&self) -> std::result::Result<(String, u64), AuthError> {
-        let conn = fetch_xet_connection_info(&self.api, self.token_type, &self.repo_id, self.repo_type, &self.revision)
-            .await
-            .map_err(|e| AuthError::token_refresh_failure(e.to_string()))?;
-        Ok(conn.token_info())
+fn xet_token_url(api: &HfApi, token_type: &str, repo_id: &str, repo_type: Option<RepoType>, revision: &str) -> String {
+    let segment = constants::repo_type_api_segment(repo_type);
+    format!("{}/api/{}/{}/xet-{}-token/{}", api.inner.endpoint, segment, repo_id, token_type, revision)
+}
+
+fn xet_file_info(hash: impl Into<String>, file_size: Option<u64>) -> XetFileInfo {
+    XetFileInfo {
+        hash: hash.into(),
+        file_size,
+        sha256: None,
     }
+}
+
+async fn prepare_xet_operation(
+    api: &HfApi,
+    token_type: &'static str,
+    repo_id: &str,
+    repo_type: Option<RepoType>,
+    revision: &str,
+) -> Result<XetOperationConfig> {
+    let conn = fetch_xet_connection_info(api, token_type, repo_id, repo_type, revision).await?;
+    let session = api.get_or_init_xet_session(&conn.endpoint)?;
+    let (token, expiry) = conn.token_info();
+
+    Ok(XetOperationConfig {
+        session,
+        token,
+        expiry,
+        refresh_url: xet_token_url(api, token_type, repo_id, repo_type, revision),
+        refresh_headers: api.auth_headers(),
+    })
+}
+
+async fn build_xet_download_group(
+    api: &HfApi,
+    repo_id: &str,
+    repo_type: Option<RepoType>,
+    revision: &str,
+) -> Result<xet::xet_session::XetFileDownloadGroup> {
+    let config = prepare_xet_operation(api, "read", repo_id, repo_type, revision).await?;
+
+    config
+        .session
+        .new_file_download_group()
+        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?
+        .with_token_info(config.token, config.expiry)
+        .with_token_refresh_url(config.refresh_url, config.refresh_headers)
+        .build()
+        .await
+        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))
+}
+
+async fn build_xet_upload_commit(
+    api: &HfApi,
+    repo_id: &str,
+    repo_type: Option<RepoType>,
+    revision: &str,
+) -> Result<xet::xet_session::XetUploadCommit> {
+    let config = prepare_xet_operation(api, "write", repo_id, repo_type, revision).await?;
+
+    config
+        .session
+        .new_upload_commit()
+        .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?
+        .with_token_info(config.token, config.expiry)
+        .with_token_refresh_url(config.refresh_url, config.refresh_headers)
+        .build()
+        .await
+        .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))
 }
 
 /// Fetch xet connection info (read or write token) from the Hub API.
@@ -64,8 +122,7 @@ async fn fetch_xet_connection_info(
     repo_type: Option<RepoType>,
     revision: &str,
 ) -> Result<XetConnectionInfo> {
-    let segment = constants::repo_type_api_segment(repo_type);
-    let url = format!("{}/api/{}/{}/xet-{}-token/{}", api.inner.endpoint, segment, repo_id, token_type, revision);
+    let url = xet_token_url(api, token_type, repo_id, repo_type, revision);
 
     let response = api.inner.client.get(&url).headers(api.auth_headers()).send().await?;
 
@@ -104,7 +161,7 @@ pub(crate) async fn xet_download_to_local_dir(
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
-    let session = api.get_or_init_xet_session("read", repo_id, repo_type, revision).await?;
+    let group = build_xet_download_group(api, repo_id, repo_type, revision).await?;
 
     tokio::fs::create_dir_all(local_dir).await?;
     let dest_path = local_dir.join(filename);
@@ -112,19 +169,8 @@ pub(crate) async fn xet_download_to_local_dir(
         tokio::fs::create_dir_all(parent).await?;
     }
 
-    let group = session
-        .new_download_group()
-        .await
-        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
-
-    let file_info = XetFileInfo {
-        hash: file_hash,
-        file_size,
-        sha256: None,
-    };
-
     group
-        .download_file_to_path(file_info, dest_path.clone())
+        .download_file_to_path(xet_file_info(file_hash, Some(file_size)), dest_path.clone())
         .await
         .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
 
@@ -145,7 +191,7 @@ pub(crate) async fn xet_download_to_blob(
     file_size: u64,
     path: &std::path::Path,
 ) -> Result<()> {
-    let session = api.get_or_init_xet_session("read", repo_id, repo_type, revision).await?;
+    let group = build_xet_download_group(api, repo_id, repo_type, revision).await?;
 
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -153,19 +199,8 @@ pub(crate) async fn xet_download_to_blob(
 
     let incomplete_path = PathBuf::from(format!("{}.incomplete", path.display()));
 
-    let group = session
-        .new_download_group()
-        .await
-        .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
-
-    let file_info = XetFileInfo {
-        hash: file_hash.to_string(),
-        file_size,
-        sha256: None,
-    };
-
     group
-        .download_file_to_path(file_info, incomplete_path.clone())
+        .download_file_to_path(xet_file_info(file_hash.to_string(), Some(file_size)), incomplete_path.clone())
         .await
         .map_err(|e| HfError::Other(format!("Xet download failed: {e}")))?;
 
@@ -195,10 +230,7 @@ pub(crate) async fn xet_download_batch(
         return Ok(());
     }
 
-    let session = api.get_or_init_xet_session("read", repo_id, repo_type, revision).await?;
-
-    let group = session
-        .new_download_group()
+    let group = build_xet_download_group(api, repo_id, repo_type, revision)
         .await
         .map_err(|e| HfError::Other(format!("Xet batch download failed: {e}")))?;
 
@@ -210,14 +242,8 @@ pub(crate) async fn xet_download_batch(
 
         let incomplete = PathBuf::from(format!("{}.incomplete", file.path.display()));
 
-        let file_info = XetFileInfo {
-            hash: file.hash.clone(),
-            file_size: file.file_size,
-            sha256: None,
-        };
-
         group
-            .download_file_to_path(file_info, incomplete.clone())
+            .download_file_to_path(xet_file_info(file.hash.clone(), Some(file.file_size)), incomplete.clone())
             .await
             .map_err(|e| HfError::Other(format!("Xet batch download failed: {e}")))?;
 
@@ -246,12 +272,7 @@ pub(crate) async fn xet_upload(
     repo_type: Option<RepoType>,
     revision: &str,
 ) -> Result<Vec<XetFileInfo>> {
-    let session = api.get_or_init_xet_session("write", repo_id, repo_type, revision).await?;
-
-    let commit = session
-        .new_upload_commit()
-        .await
-        .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?;
+    let commit = build_xet_upload_commit(api, repo_id, repo_type, revision).await?;
 
     let mut task_ids_in_order = Vec::with_capacity(files.len());
 
@@ -266,7 +287,7 @@ pub(crate) async fn xet_upload(
                 .await
                 .map_err(|e| HfError::Other(format!("Xet upload failed: {e}")))?,
         };
-        task_ids_in_order.push(handle.task_id);
+        task_ids_in_order.push(handle.task_id());
     }
 
     let results = commit
@@ -276,64 +297,38 @@ pub(crate) async fn xet_upload(
 
     let mut xet_file_infos = Vec::with_capacity(files.len());
     for task_id in &task_ids_in_order {
-        let result = results
+        let metadata = results
+            .uploads
             .get(task_id)
             .ok_or_else(|| HfError::Other("Missing xet upload result for task".to_string()))?;
-        let metadata: &FileMetadata = result
-            .as_ref()
-            .as_ref()
-            .map_err(|e| HfError::Other(format!("Xet upload task failed: {e}")))?;
-        xet_file_infos.push(XetFileInfo {
-            hash: metadata.hash.clone(),
-            file_size: metadata.file_size,
-            sha256: metadata.sha256.clone(),
-        });
+        xet_file_infos.push(metadata.xet_info.clone());
     }
 
     Ok(xet_file_infos)
 }
 
 impl HfApi {
-    /// Return the cached XetSession, creating it on first use.
+    /// Return the cached XetSession for an endpoint, creating it on first use.
     ///
-    /// The session is built once per HfApi lifetime and reused for all
-    /// subsequent xet operations. A token refresher is installed so the
-    /// session can renew its CAS credentials when they expire.
-    async fn get_or_init_xet_session(
-        &self,
-        token_type: &'static str,
-        repo_id: &str,
-        repo_type: Option<RepoType>,
-        revision: &str,
-    ) -> Result<xet::xet_session::XetSession> {
+    /// The session is reused across operations targeting the same CAS endpoint.
+    /// Read/write credentials are configured on the per-operation builders.
+    fn get_or_init_xet_session(&self, endpoint: &str) -> Result<xet::xet_session::XetSession> {
         {
             let guard = self
                 .inner
                 .xet_session
                 .lock()
                 .map_err(|e| HfError::Other(format!("xet session lock poisoned: {e}")))?;
-            if let Some(session) = guard.as_ref() {
-                return Ok(session.clone());
+            if let Some(cached) = guard.as_ref() {
+                if cached.endpoint == endpoint {
+                    return Ok(cached.session.clone());
+                }
             }
         }
 
-        let conn = fetch_xet_connection_info(self, token_type, repo_id, repo_type, revision).await?;
-
-        let token_refresher: Arc<dyn TokenRefresher> = Arc::new(HubTokenRefresher {
-            api: self.clone(),
-            repo_id: repo_id.to_string(),
-            repo_type,
-            revision: revision.to_string(),
-            token_type,
-        });
-
-        let (token, expiry) = conn.token_info();
         let session = XetSessionBuilder::new()
-            .with_endpoint(conn.endpoint.clone())
-            .with_token_info(token, expiry)
-            .with_token_refresher(token_refresher)
-            .build_async()
-            .await
+            .with_endpoint(endpoint.to_string())
+            .build()
             .map_err(|e| HfError::Other(format!("Failed to build xet session: {e}")))?;
 
         let mut guard = self
@@ -342,9 +337,20 @@ impl HfApi {
             .lock()
             .map_err(|e| HfError::Other(format!("xet session lock poisoned: {e}")))?;
         if let Some(existing) = guard.as_ref() {
-            Ok(existing.clone())
+            if existing.endpoint == endpoint {
+                Ok(existing.session.clone())
+            } else {
+                *guard = Some(CachedXetSession {
+                    endpoint: endpoint.to_string(),
+                    session: session.clone(),
+                });
+                Ok(session)
+            }
         } else {
-            *guard = Some(session.clone());
+            *guard = Some(CachedXetSession {
+                endpoint: endpoint.to_string(),
+                session: session.clone(),
+            });
             Ok(session)
         }
     }


### PR DESCRIPTION
## Summary
- update the hf-xet and xet-client git rev pins to the latest xet-core main commit
- migrate the internal xet adapter to the new per-operation builder auth model and endpoint-aware session cache
- keep existing xet download/upload behavior intact while adapting to the new upstream APIs

## Testing
- cargo +nightly fmt
- cargo clippy -p huggingface-hub --features xet -- -D warnings
- cargo test -p huggingface-hub --features xet --test cache_test --test xet_transfer_test
- cargo test -p huggingface-hub --features "xet blocking" --test blocking_test

## Notes
- cargo test -p huggingface-hub --features xet still hits the existing blocking_test feature mismatch unless the blocking feature is enabled