### PR TITLE
feat: use published xet-core crates (v1.5) instead of git deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,8 +859,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-xet"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=2659c69#2659c69892684b39fb926403a9add74d0fc1bf58"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c263f8e6508e4f3a616cd580597c59862d7f44f004b5e654a1329d92637e5f53"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,8 +3400,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=2659c69#2659c69892684b39fb926403a9add74d0fc1bf58"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b05838f0c85303e331ae54926cf197ddf1498e8d4b97467cbb1ad0d199dd6d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3438,8 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=2659c69#2659c69892684b39fb926403a9add74d0fc1bf58"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4c112a2b3a69b2fcccc3f69f93f059e27c9437b57733e3acc71d3af3facf464"
 dependencies = [
  "async-trait",
  "base64",
@@ -3474,8 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=2659c69#2659c69892684b39fb926403a9add74d0fc1bf58"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf1cb808192c1bac9067022f84fd67f97e1e908ac8206caee3fb5c7146581d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3506,8 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=2659c69#2659c69892684b39fb926403a9add74d0fc1bf58"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd0b331ef495dfba9ddfb9552cb00cd777712534551af11ecbd15deb9399e6b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/huggingface_hub/Cargo.toml
+++ b/huggingface_hub/Cargo.toml
@@ -22,8 +22,8 @@ base64 = "0.22"
 fs4 = { version = "0.13", features = ["tokio"] }
 pathdiff = "0.2"
 async-trait = { version = "0.1", optional = true }
-hf-xet = { git = "https://github.com/huggingface/xet-core.git", rev = "2659c69", optional = true }
-xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "2659c69", optional = true }
+hf-xet = { version = "1.5", optional = true }
+xet-client = { version = "1.5", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 [features]


### PR DESCRIPTION
## Summary
- Replace git-pinned `hf-xet` and `xet-client` dependencies (rev `2659c69`) with their officially published crates.io versions (`1.5`)
- No code changes required — the public API is compatible

## Test plan
- [x] `cargo clippy -p huggingface-hub --features xet -- -D warnings` passes cleanly
- [x] `cargo build -p huggingface-hub --features xet --release` succeeds
- [ ] CI passes