### PR TITLE
fix: show the error body in hf response

### DIFF
--- a/huggingface_hub/src/error.rs
+++ b/huggingface_hub/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum HFError {
-    #[error("HTTP error: {status} {url}")]
+    #[error("HTTP error: {status} {url}\n{body}")]
     Http {
         status: reqwest::StatusCode,
         url: String,


### PR DESCRIPTION
This PR simply emits the error body when hf backend throws